### PR TITLE
Feat: 아키텍쳐 설계 및 유저기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,15 +26,45 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// Spring Boot Starter Dependencies
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// Database & Redis
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.23.1'
+
+	// AWS S3
+	implementation 'software.amazon.awssdk:s3:2.21.29'
+	implementation 'software.amazon.awssdk:auth:2.21.29'
+	implementation 'software.amazon.awssdk:regions:2.21.29'
+
+	// Lombok
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	// Test Dependencies
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.testcontainers:testcontainers:1.20.5'
+	testImplementation 'org.testcontainers:junit-jupiter:1.20.5'
+
+	// monitoring
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	// etc
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/knu/storyboard/StoryboardApplication.java
+++ b/src/main/java/com/knu/storyboard/StoryboardApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class StoryboardApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(StoryboardApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(StoryboardApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/knu/storyboard/auth/business/dto/JwtRefreshRequest.java
+++ b/src/main/java/com/knu/storyboard/auth/business/dto/JwtRefreshRequest.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.auth.business.dto;
+
+public record JwtRefreshRequest(
+        String refreshToken,
+        String deviceType
+) {
+}

--- a/src/main/java/com/knu/storyboard/auth/business/dto/JwtResponse.java
+++ b/src/main/java/com/knu/storyboard/auth/business/dto/JwtResponse.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.auth.business.dto;
+
+public record JwtResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/knu/storyboard/auth/business/dto/OAuthContext.java
+++ b/src/main/java/com/knu/storyboard/auth/business/dto/OAuthContext.java
@@ -1,0 +1,16 @@
+package com.knu.storyboard.auth.business.dto;
+
+import com.knu.storyboard.auth.domain.DeviceType;
+import com.knu.storyboard.auth.domain.OAuthProvider;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PROTECTED)
+public record OAuthContext(OAuthProvider oAuthProvider, DeviceType deviceType) {
+    public static OAuthContext of(OAuthProvider oAuthProvider, DeviceType deviceType) {
+        return OAuthContext.builder()
+                .oAuthProvider(oAuthProvider)
+                .deviceType(deviceType)
+                .build();
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/business/dto/OAuthLoginResponse.java
+++ b/src/main/java/com/knu/storyboard/auth/business/dto/OAuthLoginResponse.java
@@ -1,0 +1,17 @@
+package com.knu.storyboard.auth.business.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PROTECTED)
+public record OAuthLoginResponse(
+        String accessToken,
+        String refreshToken
+) {
+    public static OAuthLoginResponse toJwt(String accessToken, String refreshToken) {
+        return OAuthLoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/business/dto/OAuthMappingEntityDto.java
+++ b/src/main/java/com/knu/storyboard/auth/business/dto/OAuthMappingEntityDto.java
@@ -1,0 +1,36 @@
+package com.knu.storyboard.auth.business.dto;
+
+import com.knu.storyboard.auth.domain.OAuthProvider;
+import com.knu.storyboard.auth.domain.OAuthToken;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class OAuthMappingEntityDto {
+    private final UUID id;
+    private final String socialUserId;
+    private final String socialUserEmail;
+    private final String socialUserName;
+    private final OAuthProvider provider;
+    private final UUID userId;
+    private final OAuthToken oauthToken;
+    private final boolean temporary;
+
+    public static OAuthMappingEntityDto create(UUID id, String providerId, String providerEmail,
+                                               String providerName, OAuthProvider provider,
+                                               UUID userId, OAuthToken oauthToken, boolean temporary) {
+        return OAuthMappingEntityDto.builder()
+                .id(id)
+                .socialUserId(providerId)
+                .socialUserEmail(providerEmail)
+                .socialUserName(providerName)
+                .provider(provider)
+                .userId(userId)
+                .oauthToken(oauthToken)
+                .temporary(temporary)
+                .build();
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/business/dto/OAuthTokenDto.java
+++ b/src/main/java/com/knu/storyboard/auth/business/dto/OAuthTokenDto.java
@@ -1,0 +1,20 @@
+package com.knu.storyboard.auth.business.dto;
+
+import com.knu.storyboard.auth.domain.OAuthToken;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PROTECTED)
+public record OAuthTokenDto(
+        String accessToken,
+        String refreshToken,
+        long expiresIn) {
+
+    public static OAuthTokenDto from(OAuthToken oAuthToken) {
+        return OAuthTokenDto.builder()
+                .accessToken(oAuthToken.getAccessToken())
+                .refreshToken(oAuthToken.getRefreshToken())
+                .expiresIn(oAuthToken.getExpiresIn())
+                .build();
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/business/dto/TokenDTO.java
+++ b/src/main/java/com/knu/storyboard/auth/business/dto/TokenDTO.java
@@ -1,0 +1,13 @@
+package com.knu.storyboard.auth.business.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PROTECTED)
+public record TokenDTO(
+        String value
+) {
+    public static TokenDTO from(String value) {
+        return TokenDTO.builder().value(value).build();
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/business/port/OAuthRepository.java
+++ b/src/main/java/com/knu/storyboard/auth/business/port/OAuthRepository.java
@@ -1,0 +1,19 @@
+package com.knu.storyboard.auth.business.port;
+
+import com.knu.storyboard.auth.business.dto.OAuthMappingEntityDto;
+import com.knu.storyboard.auth.business.dto.OAuthTokenDto;
+import com.knu.storyboard.auth.domain.OAuthProvider;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OAuthRepository {
+
+    OAuthMappingEntityDto save(OAuthMappingEntityDto entityDto);
+
+    Optional<OAuthMappingEntityDto> findBySocialUserIdAndProvider(String socialUserId, OAuthProvider provider);
+
+    void updateToken(UUID mappingId, OAuthTokenDto oauthTokenDto);
+
+    void deleteByUserId(UUID userId);
+}

--- a/src/main/java/com/knu/storyboard/auth/business/port/OAuthService.java
+++ b/src/main/java/com/knu/storyboard/auth/business/port/OAuthService.java
@@ -1,0 +1,11 @@
+package com.knu.storyboard.auth.business.port;
+
+import com.knu.storyboard.auth.domain.OAuthUserInfo;
+
+public interface OAuthService {
+    OAuthUserInfo getUserInfo(String code);
+
+    String getRedirectUrl(String state);
+
+    boolean isBackendRedirect();
+}

--- a/src/main/java/com/knu/storyboard/auth/business/port/TokenRepository.java
+++ b/src/main/java/com/knu/storyboard/auth/business/port/TokenRepository.java
@@ -1,0 +1,18 @@
+package com.knu.storyboard.auth.business.port;
+
+import com.knu.storyboard.auth.business.dto.TokenDTO;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TokenRepository {
+    void saveToken(UUID userId, String deviceType, TokenDTO tokenDTO);
+
+    TokenDTO findToken(UUID userId, String deviceType);
+
+    void removeToken(UUID userId, String deviceType);
+
+    Optional<Long> getLastRefreshTime(UUID userId, String deviceType);
+
+    void updateLastRefreshTime(UUID userId, String deviceType);
+}

--- a/src/main/java/com/knu/storyboard/auth/business/service/JwtFactory.java
+++ b/src/main/java/com/knu/storyboard/auth/business/service/JwtFactory.java
@@ -1,0 +1,72 @@
+package com.knu.storyboard.auth.business.service;
+
+import com.knu.storyboard.auth.domain.Token;
+import com.knu.storyboard.auth.domain.TokenType;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class JwtFactory {
+    public static final long REFRESH_TOKEN_VALIDITY_MILLISECONDS = 14 * 24 * 60 * 60 * 1000;
+    private static final long ACCESS_TOKEN_VALIDITY_MILLISECONDS = 30 * 60 * 1000;
+    private final SecretKey secretKey;
+
+    public JwtFactory(@Value("${SECRET_KEY}") String secret) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public Token createAccessToken(UUID userId) {
+        return createToken(userId, TokenType.ACCESS, ACCESS_TOKEN_VALIDITY_MILLISECONDS);
+    }
+
+    public Token createRefreshToken(UUID userId) {
+        return createToken(userId, TokenType.REFRESH, REFRESH_TOKEN_VALIDITY_MILLISECONDS);
+    }
+
+    private Token createToken(UUID userId, TokenType tokenType, long validityInMilliseconds) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        String tokenValue = Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(validity)
+                .claim("type", tokenType.name())
+                .signWith(secretKey)
+                .compact();
+
+        return Token.of(tokenType, tokenValue, String.valueOf(userId), now, validity);
+    }
+
+    public Optional<Token> parseToken(String tokenValue) {
+        if (tokenValue == null || tokenValue.isEmpty()) {
+            return Optional.empty();
+        }
+
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(tokenValue)
+                    .getPayload();
+
+            String subject = claims.getSubject();
+            Date issuedAt = claims.getIssuedAt();
+            Date expiration = claims.getExpiration();
+            String tokenTypeStr = claims.get("type", String.class);
+            TokenType tokenType = TokenType.valueOf(tokenTypeStr);
+
+            return Optional.of(Token.of(tokenType, tokenValue, subject, issuedAt, expiration));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/business/service/JwtService.java
+++ b/src/main/java/com/knu/storyboard/auth/business/service/JwtService.java
@@ -1,0 +1,47 @@
+package com.knu.storyboard.auth.business.service;
+
+import com.knu.storyboard.auth.business.dto.JwtRefreshRequest;
+import com.knu.storyboard.auth.business.dto.JwtResponse;
+import com.knu.storyboard.auth.business.dto.TokenDTO;
+import com.knu.storyboard.auth.business.port.TokenRepository;
+import com.knu.storyboard.auth.business.service.validator.JwtValidator;
+import com.knu.storyboard.auth.domain.Token;
+import com.knu.storyboard.auth.exception.TokenBadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+    private final JwtFactory jwtFactory;
+    private final TokenRepository tokenRepository;
+    private final JwtValidator JWTValidator;
+
+    public JwtResponse refreshAccessToken(JwtRefreshRequest request) {
+        String refreshTokenValue = request.refreshToken();
+        String deviceType = request.deviceType();
+
+        Token refreshToken = jwtFactory.parseToken(refreshTokenValue)
+                .orElseThrow(() -> new TokenBadRequestException("유효하지 않은 토큰입니다."));
+
+        UUID userId = UUID.fromString(refreshToken.getSubject());
+
+        JWTValidator.validateRefreshToken(refreshToken, userId, deviceType);
+
+        Token newAccessToken = jwtFactory.createAccessToken(userId);
+        Token newRefreshToken = jwtFactory.createRefreshToken(userId);
+
+        TokenDTO newRefreshTokenDTO = newRefreshToken.toTokenDTO();
+
+        tokenRepository.saveToken(userId, deviceType, newRefreshTokenDTO);
+        tokenRepository.updateLastRefreshTime(userId, deviceType);
+
+        return new JwtResponse(newAccessToken.getValue(), newRefreshToken.getValue());
+    }
+
+    public void logout(UUID userId, String deviceType) {
+        tokenRepository.removeToken(userId, deviceType.toUpperCase());
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/business/service/OAuthLoginService.java
+++ b/src/main/java/com/knu/storyboard/auth/business/service/OAuthLoginService.java
@@ -1,0 +1,150 @@
+package com.knu.storyboard.auth.business.service;
+
+import com.knu.storyboard.auth.business.dto.*;
+import com.knu.storyboard.auth.business.port.OAuthRepository;
+import com.knu.storyboard.auth.business.port.OAuthService;
+import com.knu.storyboard.auth.business.port.TokenRepository;
+import com.knu.storyboard.auth.domain.*;
+import com.knu.storyboard.auth.exception.OAuthBadRequestException;
+import com.knu.storyboard.user.business.dto.UserEntityDto;
+import com.knu.storyboard.user.business.port.UserRepository;
+import com.knu.storyboard.user.business.service.UserFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthLoginService {
+
+    private final Map<String, OAuthService> oAuthServices;
+    private final OAuthRepository oAuthRepository;
+    private final UserRepository userRepository;
+    private final JwtFactory jwtFactory;
+    private final TokenRepository tokenRepository;
+
+    @Value("${OAUTH_APP_REDIRECT_URI}")
+    private String appRedirectUri;
+
+    public String getOAuthLoginUrl(String provider, String state) {
+        OAuthContext context = parseOAuthContext(provider, state);
+
+        OAuthService oAuthService = getOAuthService(context.oAuthProvider());
+
+        if (!oAuthService.isBackendRedirect()) {
+            throw new OAuthBadRequestException("이 제공자는 백엔드 리다이렉트를 지원하지 않습니다.");
+        }
+
+        return oAuthService.getRedirectUrl(context.deviceType().name());
+    }
+
+    @Transactional
+    public URI handleOAuthCallback(String provider, String code, String state) {
+        OAuthContext context = parseOAuthContext(provider, state);
+
+        OAuthLoginResponse loginResponse = processOAuthLogin(context.oAuthProvider(), code,
+                context.deviceType());
+
+        StringBuilder redirectBuilder = new StringBuilder(appRedirectUri);
+
+        String urlFragmentDelimiter = "#";
+
+        redirectBuilder.append(urlFragmentDelimiter)
+                .append("accessToken=").append(loginResponse.accessToken())
+                .append("&refreshToken=").append(loginResponse.refreshToken());
+
+        return URI.create(redirectBuilder.toString());
+    }
+
+    private OAuthContext parseOAuthContext(String provider, String state) {
+        OAuthProvider oAuthProvider = OAuthProvider.fromString(provider);
+        DeviceType deviceType = DeviceType.fromString(state);
+        return OAuthContext.of(oAuthProvider, deviceType);
+    }
+
+    @Transactional
+    public OAuthLoginResponse processOAuthLogin(OAuthProvider provider, String code, DeviceType deviceType) {
+        OAuthService oAuthService = getOAuthService(provider);
+
+        OAuthUserInfo userInfo = oAuthService.getUserInfo(code);
+        String email = userInfo.getEmail();
+
+        Optional<UserEntityDto> existingUser = userRepository.findOptionalByEmail(email);
+
+        if (existingUser.isPresent()) {
+            UserEntityDto userDto = existingUser.get();
+
+            Optional<OAuthMappingEntityDto> existingMappingDto =
+                    oAuthRepository.findBySocialUserIdAndProvider(userInfo.getSocialUserId(), provider);
+
+            if (existingMappingDto.isPresent()) {
+                OAuthToken oauthToken = userInfo.getOAuthToken();
+                OAuthTokenDto oauthTokenDto = OAuthTokenDto.from(oauthToken);
+                oAuthRepository.updateToken(existingMappingDto.get().getId(), oauthTokenDto);
+            } else {
+                OAuthToken oauthToken = userInfo.getOAuthToken();
+                OAuthMapping newMapping = OAuthMapping.createForUser(
+                        userDto.getId(),
+                        userInfo.getSocialUserId(),
+                        email,
+                        userInfo.getName(),
+                        provider,
+                        oauthToken
+                );
+                oAuthRepository.save(newMapping.toDto());
+            }
+
+            JwtResponse jwtResponse = generateTokensForUser(userDto.getId(), deviceType);
+            return OAuthLoginResponse.toJwt(jwtResponse.accessToken(), jwtResponse.refreshToken());
+        } else {
+            String nickname = UserFactory.generateNicknameFromEmail(email);
+            UserEntityDto newUserDto = userRepository.save(email, nickname, "ACTIVE");
+
+            OAuthToken oauthToken = userInfo.getOAuthToken();
+            OAuthMapping newMapping = OAuthMapping.createForUser(
+                    newUserDto.getId(),
+                    userInfo.getSocialUserId(),
+                    email,
+                    userInfo.getName(),
+                    provider,
+                    oauthToken
+            );
+            oAuthRepository.save(newMapping.toDto());
+
+            JwtResponse jwtResponse = generateTokensForUser(newUserDto.getId(), deviceType);
+            return OAuthLoginResponse.toJwt(jwtResponse.accessToken(), jwtResponse.refreshToken());
+        }
+    }
+
+    public JwtResponse generateTokensForUser(UUID userId, DeviceType deviceType) {
+        UserEntityDto userEntityDto = userRepository.getById(userId);
+        UserFactory.create(userEntityDto.getId(), userEntityDto.getEmail(),
+                userEntityDto.getNickname(), userEntityDto.getStatus());
+
+        Token accessToken = jwtFactory.createAccessToken(userId);
+        Token refreshToken = jwtFactory.createRefreshToken(userId);
+
+        TokenDTO refreshTokenDTO = refreshToken.toTokenDTO();
+
+        tokenRepository.saveToken(userId, deviceType.name(), refreshTokenDTO);
+
+        return new JwtResponse(accessToken.getValue(), refreshToken.getValue());
+    }
+
+    private OAuthService getOAuthService(OAuthProvider provider) {
+        String serviceBeanName = provider.name().toLowerCase() + "OAuthService";
+        OAuthService service = oAuthServices.get(serviceBeanName);
+
+        if (service == null) {
+            throw new OAuthBadRequestException("지원하지 않는 OAuth 제공자입니다: " + provider);
+        }
+
+        return service;
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/business/service/kakao/KakaoOAuthService.java
+++ b/src/main/java/com/knu/storyboard/auth/business/service/kakao/KakaoOAuthService.java
@@ -1,0 +1,105 @@
+package com.knu.storyboard.auth.business.service.kakao;
+
+import com.knu.storyboard.auth.business.port.OAuthService;
+import com.knu.storyboard.auth.domain.OAuthProvider;
+import com.knu.storyboard.auth.domain.OAuthToken;
+import com.knu.storyboard.auth.domain.OAuthUserInfo;
+import com.knu.storyboard.auth.exception.OAuthErrorException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService implements OAuthService {
+
+    private static final String KAKAO_TOKEN_URI = "https://kauth.kakao.com/oauth/token";
+    private static final String KAKAO_USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+    private static final String KAKAO_AUTHORIZE_URI = "https://kauth.kakao.com/oauth/authorize";
+    private final RestTemplate restTemplate;
+
+    @Value("${KAKAO_REST_API_KEY}")
+    private String clientId;
+
+    @Value("${KAKAO_BACKEND_REDIRECT_URI}")
+    private String redirectUri;
+
+    @Override
+    public OAuthUserInfo getUserInfo(String code) {
+        OAuthToken oauthToken = getOAuthToken(code);
+
+        return getUserInfoByToken(oauthToken);
+    }
+
+    @Override
+    public String getRedirectUrl(String state) {
+
+        return KAKAO_AUTHORIZE_URI
+                + "?client_id=" + clientId
+                + "&redirect_uri=" + redirectUri
+                + "&response_type=code"
+                + "&state=" + state;
+    }
+
+    @Override
+    public boolean isBackendRedirect() {
+        return true;
+    }
+
+    private OAuthToken getOAuthToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+                    KAKAO_TOKEN_URI,
+                    HttpMethod.POST,
+                    request,
+                    KakaoTokenResponse.class
+            );
+
+            KakaoTokenResponse kakaoTokenResponse = response.getBody();
+
+            return kakaoTokenResponse.toDomain();
+
+        } catch (Exception e) {
+            throw new OAuthErrorException("카카오 로그인 처리 중 오류가 발생했습니다.");
+        }
+    }
+
+    private OAuthUserInfo getUserInfoByToken(OAuthToken oauthToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(oauthToken.getAccessToken());
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoUserInfoResponse> response = restTemplate.exchange(
+                    KAKAO_USER_INFO_URI,
+                    HttpMethod.GET,
+                    request,
+                    KakaoUserInfoResponse.class
+            );
+
+            KakaoUserInfoResponse userInfoResponse = response.getBody();
+
+            return userInfoResponse.toDomain(OAuthProvider.KAKAO, oauthToken);
+
+        } catch (Exception e) {
+            throw new OAuthErrorException("카카오 로그인 처리 중 오류가 발생했습니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/knu/storyboard/auth/business/service/kakao/KakaoTokenResponse.java
+++ b/src/main/java/com/knu/storyboard/auth/business/service/kakao/KakaoTokenResponse.java
@@ -1,0 +1,17 @@
+package com.knu.storyboard.auth.business.service.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.knu.storyboard.auth.domain.OAuthToken;
+
+public record KakaoTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("expires_in") Long expiresIn,
+        @JsonProperty("refresh_token_expires_in") Long refreshTokenExpiresIn,
+        @JsonProperty("token_type") String tokenType,
+        String scope
+) {
+    public OAuthToken toDomain() {
+        return OAuthToken.ofKakao(this.accessToken, this.refreshToken, this.expiresIn);
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/business/service/kakao/KakaoUserInfoResponse.java
+++ b/src/main/java/com/knu/storyboard/auth/business/service/kakao/KakaoUserInfoResponse.java
@@ -1,0 +1,29 @@
+package com.knu.storyboard.auth.business.service.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.knu.storyboard.auth.domain.OAuthProvider;
+import com.knu.storyboard.auth.domain.OAuthToken;
+import com.knu.storyboard.auth.domain.OAuthUserInfo;
+
+public record KakaoUserInfoResponse(
+        String id,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+    public OAuthUserInfo toDomain(OAuthProvider provider, OAuthToken oAuthToken) {
+        String email = kakaoAccount != null ? kakaoAccount.email : null;
+        String nickname = kakaoAccount != null && kakaoAccount.profile != null
+                ? kakaoAccount.profile.nickname : null;
+
+        return OAuthUserInfo.create(id, email, nickname, provider, oAuthToken);
+    }
+
+    public record KakaoAccount(
+            String email,
+            Profile profile
+    ) {
+        public record Profile(
+                String nickname
+        ) {
+        }
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/business/service/validator/JwtValidator.java
+++ b/src/main/java/com/knu/storyboard/auth/business/service/validator/JwtValidator.java
@@ -1,0 +1,67 @@
+package com.knu.storyboard.auth.business.service.validator;
+
+import com.knu.storyboard.auth.business.dto.TokenDTO;
+import com.knu.storyboard.auth.business.port.TokenRepository;
+import com.knu.storyboard.auth.business.service.JwtFactory;
+import com.knu.storyboard.auth.domain.Token;
+import com.knu.storyboard.auth.exception.TokenBadRequestException;
+import com.knu.storyboard.auth.exception.TokenConflictException;
+import com.knu.storyboard.auth.exception.TokenExpiredException;
+import com.knu.storyboard.auth.exception.TokenStolenException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class JwtValidator {
+    private static final long REFRESH_RATE_LIMIT_MILLISECONDS = 60 * 1000;
+
+    private final TokenRepository tokenRepository;
+    private final JwtFactory jwtFactory;
+
+    public void validateRefreshToken(Token token, UUID userId, String deviceType) {
+        if (!token.isRefreshToken()) {
+            throw new TokenBadRequestException("리프레시 토큰이 아닙니다.");
+        }
+
+        if (token.isExpired()) {
+            throw new TokenExpiredException("리프레시 토큰이 만료되었습니다.");
+        }
+
+        TokenDTO storedTokenDTO = tokenRepository.findToken(userId, deviceType);
+
+        if (storedTokenDTO.value() == null) {
+            throw new TokenBadRequestException("저장된 리프레시 토큰이 없습니다. 재로그인이 필요합니다.");
+        }
+
+        Token storedToken = jwtFactory.parseToken(storedTokenDTO.value())
+                .orElseThrow(() -> new TokenBadRequestException("유효하지 않은 토큰입니다."));
+
+        if (!storedToken.isSameValue(token.getValue())) {
+            tokenRepository.removeToken(userId, deviceType);
+            throw new TokenStolenException("리프레시 토큰이 일치하지 않습니다. 토큰 탈취 가능성.");
+        }
+
+        tokenRepository.getLastRefreshTime(userId, deviceType)
+                .ifPresent(this::checkRefreshInterval);
+    }
+
+    private void checkRefreshInterval(long lastRefreshTime) {
+        long currentTime = System.currentTimeMillis();
+        if ((currentTime - lastRefreshTime) < REFRESH_RATE_LIMIT_MILLISECONDS) {
+            throw new TokenConflictException("1분 이내에 이미 재발급 요청이 있었습니다.");
+        }
+    }
+
+    public void validateAccessToken(Token token) {
+        if (!token.isAccessToken()) {
+            throw new TokenBadRequestException("액세스 토큰이 아닙니다.");
+        }
+
+        if (token.isExpired()) {
+            throw new TokenExpiredException("액세스 토큰이 만료되었습니다.");
+        }
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/domain/AuthUser.java
+++ b/src/main/java/com/knu/storyboard/auth/domain/AuthUser.java
@@ -1,0 +1,16 @@
+package com.knu.storyboard.auth.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class AuthUser {
+    private UUID id;
+
+    public static AuthUser from(Token token) {
+        return new AuthUser(UUID.fromString(token.getSubject()));
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/domain/DeviceType.java
+++ b/src/main/java/com/knu/storyboard/auth/domain/DeviceType.java
@@ -1,0 +1,19 @@
+package com.knu.storyboard.auth.domain;
+
+import com.knu.storyboard.auth.exception.OAuthBadRequestException;
+
+public enum DeviceType {
+    COMPUTER, PHONE;
+
+    public static DeviceType fromString(String value) {
+        if (value == null || value.isEmpty()) {
+            throw new OAuthBadRequestException("state값이 없습니다.");
+        }
+
+        try {
+            return DeviceType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new OAuthBadRequestException("올바른 DeviceType이 아닙니다.");
+        }
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/domain/OAuthMapping.java
+++ b/src/main/java/com/knu/storyboard/auth/domain/OAuthMapping.java
@@ -1,0 +1,89 @@
+package com.knu.storyboard.auth.domain;
+
+import com.knu.storyboard.auth.business.dto.OAuthMappingEntityDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OAuthMapping {
+    private final UUID id;
+    private final String socialUserId;
+    private final String socialUserEmail;
+    private final String socialUserName;
+    private final OAuthProvider provider;
+    private UUID userId;
+    private OAuthToken oauthToken;
+    private boolean temporary;
+
+    public static OAuthMapping fromDto(OAuthMappingEntityDto dto) {
+        return OAuthMapping.builder()
+                .id(dto.getId())
+                .socialUserId(dto.getSocialUserId())
+                .socialUserEmail(dto.getSocialUserEmail())
+                .socialUserName(dto.getSocialUserName())
+                .provider(dto.getProvider())
+                .userId(dto.getUserId())
+                .oauthToken(dto.getOauthToken())
+                .temporary(dto.isTemporary())
+                .build();
+    }
+
+    public static OAuthMapping createTemporary(String providerId, String providerEmail,
+                                               String providerName, OAuthProvider provider, OAuthToken oauthToken) {
+        return OAuthMapping.builder()
+                .socialUserId(providerId)
+                .socialUserEmail(providerEmail)
+                .socialUserName(providerName)
+                .provider(provider)
+                .oauthToken(oauthToken)
+                .temporary(true)
+                .build();
+    }
+
+    public static OAuthMapping createForUser(UUID userId, String providerId, String providerEmail,
+                                             String providerName, OAuthProvider provider, OAuthToken oauthToken) {
+        return OAuthMapping.builder()
+                .socialUserId(providerId)
+                .socialUserEmail(providerEmail)
+                .socialUserName(providerName)
+                .provider(provider)
+                .userId(userId)
+                .oauthToken(oauthToken)
+                .temporary(false)
+                .build();
+    }
+
+    public OAuthMapping linkToUser(UUID userId) {
+        OAuthMapping linked = OAuthMapping.builder()
+                .id(id)
+                .socialUserId(socialUserId)
+                .socialUserEmail(socialUserEmail)
+                .socialUserName(socialUserName)
+                .provider(provider)
+                .userId(userId)
+                .oauthToken(oauthToken)
+                .temporary(false)
+                .build();
+
+        return linked;
+    }
+
+    public OAuthMappingEntityDto toDto() {
+        return OAuthMappingEntityDto.create(
+                id,
+                socialUserId,
+                socialUserEmail,
+                socialUserName,
+                provider,
+                userId,
+                oauthToken,
+                temporary
+        );
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/domain/OAuthProvider.java
+++ b/src/main/java/com/knu/storyboard/auth/domain/OAuthProvider.java
@@ -1,0 +1,20 @@
+package com.knu.storyboard.auth.domain;
+
+import com.knu.storyboard.auth.exception.OAuthBadRequestException;
+
+public enum OAuthProvider {
+    KAKAO, APPLE,
+    UNSUPPORTED;
+
+    public static OAuthProvider fromString(String value) {
+        if (value == null || value.isEmpty()) {
+            throw new OAuthBadRequestException("Provider 값이 없습니다.");
+        }
+
+        try {
+            return OAuthProvider.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new OAuthBadRequestException("올바른 Provider가 아닙니다.");
+        }
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/domain/OAuthToken.java
+++ b/src/main/java/com/knu/storyboard/auth/domain/OAuthToken.java
@@ -1,0 +1,50 @@
+package com.knu.storyboard.auth.domain;
+
+import com.knu.storyboard.auth.exception.OAuthErrorException;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OAuthToken {
+    private final OAuthProvider provider;
+    private final String accessToken;
+    private final String refreshToken;
+    private final Long expiresIn;
+    private final LocalDateTime issuedAt;
+
+    public static OAuthToken ofKakao(String accessToken, String refreshToken, Long expiresIn) {
+        if (accessToken == null) {
+            throw new OAuthErrorException("응답이 올바르지 않아 accessToken이 전달되지 않았습니다.");
+        }
+
+        return OAuthToken.builder()
+                .provider(OAuthProvider.KAKAO)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .expiresIn(expiresIn)
+                .issuedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static OAuthToken create(OAuthProvider provider, String accessToken, String refreshToken,
+                                    Long expiresIn) {
+
+        if (accessToken == null) {
+            return null;
+        }
+
+        return OAuthToken.builder()
+                .provider(provider)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .expiresIn(expiresIn)
+                .issuedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/domain/OAuthUserInfo.java
+++ b/src/main/java/com/knu/storyboard/auth/domain/OAuthUserInfo.java
@@ -1,0 +1,31 @@
+package com.knu.storyboard.auth.domain;
+
+import com.knu.storyboard.auth.exception.OAuthErrorException;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OAuthUserInfo {
+    private String socialUserId;
+    private String email;
+    private String name;
+    private OAuthProvider provider;
+    private OAuthToken oAuthToken;
+
+    public static OAuthUserInfo create(String socialUserId, String email, String name,
+                                       OAuthProvider provider, OAuthToken oauthToken) {
+
+        if (socialUserId == null) {
+            throw new OAuthErrorException("응답이 올바르지 않아 socialUserId가 전달되지 않았습니다.");
+        }
+
+        return OAuthUserInfo.builder()
+                .socialUserId(socialUserId)
+                .email(email)
+                .name(name == null ? "Unknown" : name)
+                .provider(provider)
+                .oAuthToken(oauthToken)
+                .build();
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/domain/Token.java
+++ b/src/main/java/com/knu/storyboard/auth/domain/Token.java
@@ -1,0 +1,43 @@
+package com.knu.storyboard.auth.domain;
+
+import com.knu.storyboard.auth.business.dto.TokenDTO;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Token {
+    private final TokenType type;
+    private final String value;
+    private final String subject;
+    private final Date issueAt;
+    private final Date expiration;
+
+    public static Token of(TokenType type, String value, String subject, Date issueAt,
+                           Date expiration) {
+        return new Token(type, value, subject, issueAt, expiration);
+    }
+
+    public boolean isExpired() {
+        return expiration.before(new Date());
+    }
+
+    public boolean isAccessToken() {
+        return this.type.equals(TokenType.ACCESS);
+    }
+
+    public boolean isRefreshToken() {
+        return this.type.equals(TokenType.REFRESH);
+    }
+
+    public boolean isSameValue(String value) {
+        return this.value.equals(value);
+    }
+
+    public TokenDTO toTokenDTO() {
+        return TokenDTO.from(this.value);
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/domain/TokenType.java
+++ b/src/main/java/com/knu/storyboard/auth/domain/TokenType.java
@@ -1,0 +1,5 @@
+package com.knu.storyboard.auth.domain;
+
+public enum TokenType {
+    ACCESS, REFRESH
+}

--- a/src/main/java/com/knu/storyboard/auth/exception/OAuthBadRequestException.java
+++ b/src/main/java/com/knu/storyboard/auth/exception/OAuthBadRequestException.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.auth.exception;
+
+public class OAuthBadRequestException extends RuntimeException {
+    public OAuthBadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/exception/OAuthErrorException.java
+++ b/src/main/java/com/knu/storyboard/auth/exception/OAuthErrorException.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.auth.exception;
+
+public class OAuthErrorException extends RuntimeException {
+    public OAuthErrorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/exception/OAuthNotFoundException.java
+++ b/src/main/java/com/knu/storyboard/auth/exception/OAuthNotFoundException.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.auth.exception;
+
+public class OAuthNotFoundException extends RuntimeException {
+    public OAuthNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/exception/TokenBadRequestException.java
+++ b/src/main/java/com/knu/storyboard/auth/exception/TokenBadRequestException.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.auth.exception;
+
+public class TokenBadRequestException extends RuntimeException {
+    public TokenBadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/exception/TokenConflictException.java
+++ b/src/main/java/com/knu/storyboard/auth/exception/TokenConflictException.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.auth.exception;
+
+public class TokenConflictException extends RuntimeException {
+    public TokenConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/exception/TokenExpiredException.java
+++ b/src/main/java/com/knu/storyboard/auth/exception/TokenExpiredException.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.auth.exception;
+
+public class TokenExpiredException extends RuntimeException {
+    public TokenExpiredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/exception/TokenStolenException.java
+++ b/src/main/java/com/knu/storyboard/auth/exception/TokenStolenException.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.auth.exception;
+
+public class TokenStolenException extends RuntimeException {
+    public TokenStolenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/infrastructure/entity/OAuthMappingEntity.java
+++ b/src/main/java/com/knu/storyboard/auth/infrastructure/entity/OAuthMappingEntity.java
@@ -1,0 +1,122 @@
+package com.knu.storyboard.auth.infrastructure.entity;
+
+import com.knu.storyboard.auth.business.dto.OAuthMappingEntityDto;
+import com.knu.storyboard.auth.business.dto.OAuthTokenDto;
+import com.knu.storyboard.auth.domain.OAuthProvider;
+import com.knu.storyboard.auth.domain.OAuthToken;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "OAUTH_MAPPING", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"socialUserId", "provider"}))
+public class OAuthMappingEntity {
+    @Id
+    @UuidGenerator
+    @Column(columnDefinition = "char(36)", updatable = false, nullable = false)
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String socialUserId;
+
+    private String socialUserEmail;
+
+    private String socialUserName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OAuthProvider provider;
+
+    @Column(columnDefinition = "char(36)")
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private UUID userId;
+
+    private String accessToken;
+
+    private String refreshToken;
+
+    private Long expiresIn;
+
+    private LocalDateTime tokenIssuedAt;
+
+    @Column(nullable = false)
+    private boolean temporary;
+
+    public static OAuthMappingEntity fromEntityDto(OAuthMappingEntityDto dto) {
+        OAuthMappingEntity entity = OAuthMappingEntity.builder()
+                .id(dto.getId())
+                .socialUserId(dto.getSocialUserId())
+                .socialUserEmail(dto.getSocialUserEmail())
+                .socialUserName(dto.getSocialUserName())
+                .provider(dto.getProvider())
+                .userId(dto.getUserId())
+                .temporary(dto.isTemporary())
+                .build();
+
+        OAuthToken oauthToken = dto.getOauthToken();
+        if (oauthToken != null) {
+            entity.accessToken = oauthToken.getAccessToken();
+            entity.refreshToken = oauthToken.getRefreshToken();
+            entity.expiresIn = oauthToken.getExpiresIn();
+            entity.tokenIssuedAt = oauthToken.getIssuedAt();
+        }
+
+        return entity;
+    }
+
+    public OAuthMappingEntityDto toEntityDto() {
+        OAuthToken oauthToken = OAuthToken.create(
+                provider, accessToken, refreshToken, expiresIn
+        );
+
+        return OAuthMappingEntityDto.create(
+                id,
+                socialUserId,
+                socialUserEmail,
+                socialUserName,
+                provider,
+                userId,
+                oauthToken,
+                temporary
+        );
+    }
+
+    public void updateFromDto(OAuthMappingEntityDto dto) {
+        if (dto.getUserId() != null) {
+            this.userId = dto.getUserId();
+        }
+
+        if (dto.getOauthToken() != null) {
+            OAuthToken token = dto.getOauthToken();
+            this.accessToken = token.getAccessToken();
+            this.refreshToken = token.getRefreshToken();
+            this.expiresIn = token.getExpiresIn();
+            this.tokenIssuedAt = token.getIssuedAt();
+        }
+
+        if (dto.getSocialUserEmail() != null) {
+            this.socialUserEmail = dto.getSocialUserEmail();
+        }
+        if (dto.getSocialUserName() != null) {
+            this.socialUserName = dto.getSocialUserName();
+        }
+        this.temporary = dto.isTemporary();
+    }
+
+    public void updateFromTokenDto(OAuthTokenDto dto) {
+        this.accessToken = dto.accessToken();
+        this.refreshToken = dto.refreshToken();
+        this.expiresIn = dto.expiresIn();
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/infrastructure/entity/OAuthMappingEntity.java
+++ b/src/main/java/com/knu/storyboard/auth/infrastructure/entity/OAuthMappingEntity.java
@@ -18,8 +18,8 @@ import java.util.UUID;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "OAUTH_MAPPING", 
-       uniqueConstraints = @UniqueConstraint(columnNames = {"socialUserId", "provider"}))
+@Table(name = "OAUTH_MAPPING",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"socialUserId", "provider"}))
 public class OAuthMappingEntity {
     @Id
     @UuidGenerator

--- a/src/main/java/com/knu/storyboard/auth/infrastructure/persistence/OAuthMappingJpaRepository.java
+++ b/src/main/java/com/knu/storyboard/auth/infrastructure/persistence/OAuthMappingJpaRepository.java
@@ -1,0 +1,20 @@
+package com.knu.storyboard.auth.infrastructure.persistence;
+
+import com.knu.storyboard.auth.domain.OAuthProvider;
+import com.knu.storyboard.auth.infrastructure.entity.OAuthMappingEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface OAuthMappingJpaRepository extends JpaRepository<OAuthMappingEntity, UUID> {
+
+    Optional<OAuthMappingEntity> findBySocialUserIdAndProvider(String socialUserId,
+                                                               OAuthProvider provider);
+
+    Optional<OAuthMappingEntity> findByIdAndProvider(UUID id, OAuthProvider provider);
+
+    void deleteByUserId(UUID userId);
+}

--- a/src/main/java/com/knu/storyboard/auth/infrastructure/persistence/OAuthRepositoryImpl.java
+++ b/src/main/java/com/knu/storyboard/auth/infrastructure/persistence/OAuthRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.knu.storyboard.auth.infrastructure.persistence;
+
+import com.knu.storyboard.auth.business.dto.OAuthMappingEntityDto;
+import com.knu.storyboard.auth.business.dto.OAuthTokenDto;
+import com.knu.storyboard.auth.business.port.OAuthRepository;
+import com.knu.storyboard.auth.domain.OAuthProvider;
+import com.knu.storyboard.auth.exception.OAuthNotFoundException;
+import com.knu.storyboard.auth.infrastructure.entity.OAuthMappingEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class OAuthRepositoryImpl implements OAuthRepository {
+
+    private final OAuthMappingJpaRepository oAuthMappingJpaRepository;
+
+    @Override
+    public OAuthMappingEntityDto save(OAuthMappingEntityDto entityDto) {
+        OAuthMappingEntity entity = OAuthMappingEntity.fromEntityDto(entityDto);
+        OAuthMappingEntity oAuthMappingEntity = oAuthMappingJpaRepository.save(entity);
+        return oAuthMappingEntity.toEntityDto();
+    }
+
+    @Override
+    public Optional<OAuthMappingEntityDto> findBySocialUserIdAndProvider(String socialUserId,
+                                                                         OAuthProvider provider) {
+        return oAuthMappingJpaRepository.findBySocialUserIdAndProvider(socialUserId, provider)
+                .map(OAuthMappingEntity::toEntityDto);
+    }
+
+    @Override
+    public void updateToken(UUID mappingId, OAuthTokenDto oauthTokenDto) {
+        OAuthMappingEntity existingEntity = oAuthMappingJpaRepository.findById(mappingId)
+                .orElseThrow(() -> new OAuthNotFoundException(
+                        "업데이트할 OAuth 매핑을 찾을 수 없습니다: " + mappingId));
+
+        existingEntity.updateFromTokenDto(oauthTokenDto);
+    }
+
+    @Override
+    public void deleteByUserId(UUID userId) {
+        oAuthMappingJpaRepository.deleteByUserId(userId);
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/infrastructure/persistence/RedisTokenRepositoryImpl.java
+++ b/src/main/java/com/knu/storyboard/auth/infrastructure/persistence/RedisTokenRepositoryImpl.java
@@ -1,0 +1,67 @@
+package com.knu.storyboard.auth.infrastructure.persistence;
+
+import com.knu.storyboard.auth.business.dto.TokenDTO;
+import com.knu.storyboard.auth.business.port.TokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static com.knu.storyboard.auth.business.service.JwtFactory.REFRESH_TOKEN_VALIDITY_MILLISECONDS;
+
+@Component
+@RequiredArgsConstructor
+public class RedisTokenRepositoryImpl implements TokenRepository {
+    private static final String TOKEN_KEY_PREFIX = "refreshToken:";
+    private static final String REFRESH_TIME_KEY_PREFIX = "refresh-time:";
+    private static final long REFRESH_REQUEST_INTERVAL_LIMIT = 60 * 1000L;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void saveToken(UUID userId, String deviceType, TokenDTO tokenDTO) {
+        String key = generateKey(userId, deviceType);
+        redisTemplate.opsForValue()
+                .set(key, tokenDTO.value(), REFRESH_TOKEN_VALIDITY_MILLISECONDS, TimeUnit.MILLISECONDS);
+        updateLastRefreshTime(userId, deviceType);
+    }
+
+    @Override
+    public TokenDTO findToken(UUID userId, String deviceType) {
+        String key = generateKey(userId, deviceType);
+        String tokenValue = redisTemplate.opsForValue().get(key);
+        return TokenDTO.from(tokenValue);
+    }
+
+    @Override
+    public void removeToken(UUID userId, String deviceType) {
+        String key = generateKey(userId, deviceType);
+        redisTemplate.delete(key);
+    }
+
+    @Override
+    public Optional<Long> getLastRefreshTime(UUID userId, String deviceType) {
+        String timeKey = generateTimeKey(userId, deviceType);
+        String value = redisTemplate.opsForValue().get(timeKey);
+        return Optional.ofNullable(value).map(Long::valueOf);
+    }
+
+    @Override
+    public void updateLastRefreshTime(UUID userId, String deviceType) {
+        String timeKey = generateTimeKey(userId, deviceType);
+        redisTemplate.opsForValue()
+                .set(timeKey, String.valueOf(System.currentTimeMillis()),
+                        REFRESH_REQUEST_INTERVAL_LIMIT, TimeUnit.MILLISECONDS);
+    }
+
+    private String generateKey(UUID userId, String deviceType) {
+        return TOKEN_KEY_PREFIX + userId + ":" + deviceType;
+    }
+
+    private String generateTimeKey(UUID userId, String deviceType) {
+        return REFRESH_TIME_KEY_PREFIX + userId + ":" + deviceType;
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/presentation/annotation/Login.java
+++ b/src/main/java/com/knu/storyboard/auth/presentation/annotation/Login.java
@@ -1,0 +1,11 @@
+package com.knu.storyboard.auth.presentation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/src/main/java/com/knu/storyboard/auth/presentation/annotation/RequireAuth.java
+++ b/src/main/java/com/knu/storyboard/auth/presentation/annotation/RequireAuth.java
@@ -1,0 +1,12 @@
+package com.knu.storyboard.auth.presentation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequireAuth {
+    boolean optional() default false;
+}

--- a/src/main/java/com/knu/storyboard/auth/presentation/api/OAuthApi.java
+++ b/src/main/java/com/knu/storyboard/auth/presentation/api/OAuthApi.java
@@ -1,0 +1,31 @@
+package com.knu.storyboard.auth.presentation.api;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.view.RedirectView;
+
+@RequestMapping("/auth/oauth")
+@Tag(name = "OAuth", description = "OAuth 관련 API")
+public interface OAuthApi {
+
+    @GetMapping("/{provider}/login")
+    @Operation(summary = "OAuth 로그인 페이지 이동",
+            description = "provider별 로그인 페이지로 이동한다. state는 deviceType(COMPUTER/PHONE)")
+    RedirectView redirectToOAuthLoginPage(
+            @PathVariable("provider") String provider,
+            @RequestParam(value = "state", required = false) String state);
+
+    @GetMapping("/{provider}/callback")
+    @Operation(summary = "OAuth용 콜백 [직접 사용 금지]",
+            description = "provider 측에서 콜백 리다이렉트로 사용할 엔드포인트. 직접 사용 금지.")
+    ResponseEntity<Void> handleOAuthCallback(
+            @PathVariable("provider") String provider,
+            @RequestParam("code") String code,
+            @RequestParam(value = "state") String state);
+}

--- a/src/main/java/com/knu/storyboard/auth/presentation/controller/OAuthController.java
+++ b/src/main/java/com/knu/storyboard/auth/presentation/controller/OAuthController.java
@@ -1,0 +1,44 @@
+package com.knu.storyboard.auth.presentation.controller;
+
+import com.knu.storyboard.auth.business.service.OAuthLoginService;
+import com.knu.storyboard.auth.presentation.api.OAuthApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+public class OAuthController implements OAuthApi {
+
+    private final OAuthLoginService oAuthLoginService;
+
+    @Override
+    public RedirectView redirectToOAuthLoginPage(
+            @PathVariable("provider") String provider,
+            @RequestParam(value = "state", required = false) String state) {
+
+        String redirectUrl = oAuthLoginService.getOAuthLoginUrl(provider, state);
+
+        return new RedirectView(redirectUrl);
+    }
+
+    @Override
+    public ResponseEntity<Void> handleOAuthCallback(
+            @PathVariable("provider") String provider,
+            @RequestParam("code") String code,
+            @RequestParam(value = "state") String state) {
+
+        URI redirectInfo = oAuthLoginService.handleOAuthCallback(provider, code, state);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(redirectInfo);
+        return new ResponseEntity<>(headers, HttpStatus.FOUND);
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/presentation/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/knu/storyboard/auth/presentation/interceptor/AuthInterceptor.java
@@ -1,0 +1,55 @@
+package com.knu.storyboard.auth.presentation.interceptor;
+
+import com.knu.storyboard.auth.business.service.JwtFactory;
+import com.knu.storyboard.auth.business.service.validator.JwtValidator;
+import com.knu.storyboard.auth.domain.Token;
+import com.knu.storyboard.auth.exception.TokenBadRequestException;
+import com.knu.storyboard.auth.presentation.annotation.RequireAuth;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+    private static final String AUTH_TOKEN_ATTRIBUTE = "AUTH_TOKEN";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private final JwtFactory jwtFactory;
+    private final JwtValidator JWTValidator;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+                             Object handler) {
+        if (!(handler instanceof HandlerMethod handlerMethod)) {
+            return true;
+        }
+
+        boolean requiresAuth = handlerMethod.hasMethodAnnotation(RequireAuth.class) ||
+                handlerMethod.getBeanType().isAnnotationPresent(RequireAuth.class);
+
+        if (!requiresAuth) {
+            return true;
+        }
+
+        String tokenValue = extractTokenFromHeader(request);
+        Token token = jwtFactory.parseToken(tokenValue)
+                .orElseThrow(() -> new TokenBadRequestException("유효하지 않은 토큰입니다. 만료되었을 수 있습니다."));
+
+        JWTValidator.validateAccessToken(token);
+
+        request.setAttribute(AUTH_TOKEN_ATTRIBUTE, token);
+
+        return true;
+    }
+
+    private String extractTokenFromHeader(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+            throw new TokenBadRequestException("Authorization 헤더가 없거나 Bearer 형식이 아닙니다.");
+        }
+        return authHeader.substring(BEARER_PREFIX.length());
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/presentation/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/knu/storyboard/auth/presentation/resolver/AuthUserArgumentResolver.java
@@ -1,0 +1,46 @@
+package com.knu.storyboard.auth.presentation.resolver;
+
+import com.knu.storyboard.auth.domain.AuthUser;
+import com.knu.storyboard.auth.domain.Token;
+import com.knu.storyboard.auth.exception.TokenBadRequestException;
+import com.knu.storyboard.auth.presentation.annotation.Login;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+    private static final String AUTH_TOKEN_ATTRIBUTE = "AUTH_TOKEN";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasAuthenticatedUserAnnotation = parameter.hasParameterAnnotation(Login.class);
+        boolean hasAuthUserParameterType = parameter.getParameterType().equals(AuthUser.class);
+
+        return hasAuthenticatedUserAnnotation && hasAuthUserParameterType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        Token token = (Token) request.getAttribute(AUTH_TOKEN_ATTRIBUTE);
+
+        if (token == null) {
+            throw new TokenBadRequestException(
+                    "인증 정보를 찾을 수 없습니다. 인증이 필요한 로직인 경우 @requiresAuth 를 추가하세요.");
+        }
+
+        return buildAuthUserFromToken(token);
+    }
+
+    private AuthUser buildAuthUserFromToken(Token token) {
+        return AuthUser.from(token);
+    }
+}

--- a/src/main/java/com/knu/storyboard/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/knu/storyboard/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.knu.storyboard.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/knu/storyboard/common/config/RedisConfig.java
+++ b/src/main/java/com/knu/storyboard/common/config/RedisConfig.java
@@ -1,0 +1,56 @@
+package com.knu.storyboard.common.config;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration serverConfig = new RedisStandaloneConfiguration(host, port);
+        serverConfig.setPassword(RedisPassword.of(password));
+
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .commandTimeout(Duration.ofMillis(500))
+                .clientOptions(ClientOptions.builder()
+                        .autoReconnect(true)
+                        .socketOptions(
+                                SocketOptions.builder().connectTimeout(Duration.ofMillis(1000)).build())
+                        .disconnectedBehavior(ClientOptions.DisconnectedBehavior.REJECT_COMMANDS)
+                        .build())
+                .build();
+
+        return new LettuceConnectionFactory(serverConfig, clientConfig);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/knu/storyboard/common/config/S3Config.java
+++ b/src/main/java/com/knu/storyboard/common/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.knu.storyboard.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/knu/storyboard/common/config/SwaggerConfig.java
+++ b/src/main/java/com/knu/storyboard/common/config/SwaggerConfig.java
@@ -1,0 +1,41 @@
+package com.knu.storyboard.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    public static final String BEARER_AUTH = "BearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(createApiInfo())
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH))
+                .schemaRequirement(BEARER_AUTH, createSecurityScheme());
+    }
+
+    private Info createApiInfo() {
+        return new Info()
+                .title("StoryBoardAI 서비스 명세서")
+                .description("경북대학교 종합설계프로젝트2")
+                .version("0.0.1");
+    }
+
+    public SecurityScheme createSecurityScheme() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+        return securityScheme;
+    }
+}

--- a/src/main/java/com/knu/storyboard/common/config/WebConfig.java
+++ b/src/main/java/com/knu/storyboard/common/config/WebConfig.java
@@ -1,0 +1,53 @@
+package com.knu.storyboard.common.config;
+
+import com.knu.storyboard.auth.presentation.interceptor.AuthInterceptor;
+import com.knu.storyboard.auth.presentation.resolver.AuthUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOriginPattern("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        config.addExposedHeader("Authorization");
+        config.setMaxAge(3600L);
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor).addPathPatterns("/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/knu/storyboard/common/dto/StringTypeResponse.java
+++ b/src/main/java/com/knu/storyboard/common/dto/StringTypeResponse.java
@@ -1,0 +1,6 @@
+package com.knu.storyboard.common.dto;
+
+public record StringTypeResponse(
+        String response
+) {
+}

--- a/src/main/java/com/knu/storyboard/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/knu/storyboard/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,96 @@
+package com.knu.storyboard.common.exception;
+
+import com.knu.storyboard.auth.exception.*;
+import com.knu.storyboard.common.file.FileStorageException;
+import com.knu.storyboard.user.exception.UserEmailDuplicateException;
+import com.knu.storyboard.user.exception.UserNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(OAuthBadRequestException.class)
+    public ResponseEntity<ProblemDetail> handleOAuthBadRequestExceptionException(OAuthBadRequestException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+        problemDetail.setTitle("OAuth Bad Request");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
+
+    @ExceptionHandler(OAuthErrorException.class)
+    public ResponseEntity<ProblemDetail> handleOAuthErrorExceptionException(OAuthErrorException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        problemDetail.setTitle("OAuth Error");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(problemDetail);
+    }
+
+    @ExceptionHandler(OAuthNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handleOAuthNotFoundExceptionException(OAuthNotFoundException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+        problemDetail.setTitle("OAuth Not Found");
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+    }
+
+    @ExceptionHandler(TokenBadRequestException.class)
+    public ResponseEntity<ProblemDetail> handleTokenBadRequestExceptionException(TokenBadRequestException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+        problemDetail.setTitle("Token Bad Request");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
+
+    @ExceptionHandler(TokenConflictException.class)
+    public ResponseEntity<ProblemDetail> handleTokenConflictExceptionException(TokenConflictException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, e.getMessage());
+        problemDetail.setTitle("Token Conflict");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(problemDetail);
+    }
+
+    @ExceptionHandler(TokenExpiredException.class)
+    public ResponseEntity<ProblemDetail> handleTokenExpiredException(TokenExpiredException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatusCode.valueOf(461), e.getMessage());
+        problemDetail.setTitle("Token Expired");
+        return ResponseEntity.status(HttpStatusCode.valueOf(461)).body(problemDetail);
+    }
+
+    @ExceptionHandler(TokenStolenException.class)
+    public ResponseEntity<ProblemDetail> handleTokenStolenException(TokenStolenException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatusCode.valueOf(462), e.getMessage());
+        problemDetail.setTitle("Token Stolen");
+        return ResponseEntity.status(HttpStatusCode.valueOf(462)).body(problemDetail);
+    }
+
+    @ExceptionHandler(UserEmailDuplicateException.class)
+    public ResponseEntity<ProblemDetail> handleUserEmailDuplicateException(UserEmailDuplicateException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+        problemDetail.setTitle("User Email Duplicate");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handleUserNotFoundException(UserNotFoundException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+        problemDetail.setTitle("User NotFound");
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+    }
+
+    @ExceptionHandler(FileStorageException.class)
+    public ResponseEntity<ProblemDetail> handleFileStorageException(FileStorageException e) {
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        problemDetail.setTitle("File Storage Exception");
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(problemDetail);
+    }
+}

--- a/src/main/java/com/knu/storyboard/common/file/FileStorageException.java
+++ b/src/main/java/com/knu/storyboard/common/file/FileStorageException.java
@@ -1,0 +1,8 @@
+package com.knu.storyboard.common.file;
+
+public class FileStorageException extends RuntimeException {
+
+    public FileStorageException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/knu/storyboard/common/file/FileStorageService.java
+++ b/src/main/java/com/knu/storyboard/common/file/FileStorageService.java
@@ -1,0 +1,12 @@
+package com.knu.storyboard.common.file;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileStorageService {
+
+    String uploadFile(MultipartFile file, String directory);
+
+    void deleteFile(String fileUrl);
+
+    boolean exists(String fileUrl);
+}

--- a/src/main/java/com/knu/storyboard/common/file/infrastructure/S3FileStorageService.java
+++ b/src/main/java/com/knu/storyboard/common/file/infrastructure/S3FileStorageService.java
@@ -1,0 +1,142 @@
+package com.knu.storyboard.common.file.infrastructure;
+
+import com.knu.storyboard.common.file.FileStorageException;
+import com.knu.storyboard.common.file.FileStorageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3FileStorageService implements FileStorageService {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Override
+    public String uploadFile(MultipartFile file, String directory) {
+        validateFile(file);
+
+        try {
+            String fileName = generateUniqueFileName(file.getOriginalFilename());
+            String dateDir = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+            String key = String.format("%s/%s/%s", directory, dateDir, fileName);
+
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
+                    .build();
+
+            s3Client.putObject(putObjectRequest,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            String fileUrl = String.format("https://%s.s3.amazonaws.com/%s", bucketName, key);
+
+            log.info("S3 파일 업로드 완료: {} -> {}", file.getOriginalFilename(), fileUrl);
+            return fileUrl;
+
+        } catch (IOException e) {
+            log.error("S3 파일 업로드 실패: {}", file.getOriginalFilename(), e);
+            throw new FileStorageException("파일 업로드에 실패했습니다: " + e.getMessage());
+        } catch (S3Exception e) {
+            log.error("S3 서비스 오류: {}", e.awsErrorDetails().errorMessage());
+            throw new FileStorageException("S3 업로드 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void deleteFile(String fileUrl) {
+        try {
+            String key = extractS3Key(fileUrl);
+
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("S3 파일 삭제 완료: {}", fileUrl);
+
+        } catch (S3Exception e) {
+            log.error("S3 파일 삭제 실패: {}", fileUrl, e);
+            throw new FileStorageException("파일 삭제에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean exists(String fileUrl) {
+        try {
+            String key = extractS3Key(fileUrl);
+
+            HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            s3Client.headObject(headObjectRequest);
+            return true;
+
+        } catch (NoSuchKeyException e) {
+            return false;
+        } catch (S3Exception e) {
+            log.error("S3 파일 존재 여부 확인 실패: {}", fileUrl, e);
+            return false;
+        }
+    }
+
+    private String generateUniqueFileName(String originalFilename) {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HHmmss"));
+        String uuid = UUID.randomUUID().toString().substring(0, 8);
+        String extension = getFileExtension(originalFilename);
+        return String.format("%s_%s%s", timestamp, uuid, extension);
+    }
+
+    private String getFileExtension(String filename) {
+        if (filename == null || filename.isEmpty()) {
+            return "";
+        }
+        int lastDotIndex = filename.lastIndexOf('.');
+        return (lastDotIndex == -1) ? "" : filename.substring(lastDotIndex);
+    }
+
+    private String extractS3Key(String fileUrl) {
+        if (fileUrl.contains(".s3.amazonaws.com/")) {
+            return fileUrl.substring(fileUrl.indexOf(".s3.amazonaws.com/") + 18);
+        }
+
+        throw new IllegalArgumentException("올바르지 않은 S3 URL 형식입니다: " + fileUrl);
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new FileStorageException("빈 파일은 업로드할 수 없습니다.");
+        }
+
+        // 파일 크기 제한 (50MB)
+        long maxSize = 50 * 1024 * 1024;
+        if (file.getSize() > maxSize) {
+            throw new FileStorageException("파일 크기는 50MB를 초과할 수 없습니다.");
+        }
+
+        // 이미지 파일만 허용
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new FileStorageException("이미지 파일만 업로드 가능합니다.");
+        }
+    }
+}

--- a/src/main/java/com/knu/storyboard/user/business/dto/DummyRequest.java
+++ b/src/main/java/com/knu/storyboard/user/business/dto/DummyRequest.java
@@ -1,0 +1,6 @@
+package com.knu.storyboard.user.business.dto;
+
+public record DummyRequest(
+        String email
+) {
+}

--- a/src/main/java/com/knu/storyboard/user/business/dto/UserEntityDto.java
+++ b/src/main/java/com/knu/storyboard/user/business/dto/UserEntityDto.java
@@ -1,0 +1,41 @@
+package com.knu.storyboard.user.business.dto;
+
+import com.knu.storyboard.user.business.service.UserFactory;
+import com.knu.storyboard.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserEntityDto {
+    private final UUID id;
+    private final String email;
+    private final String nickname;
+    private final String status;
+
+    public static UserEntityDto create(UUID id, String email, String nickname, String status) {
+        return UserEntityDto.builder()
+                .id(id)
+                .email(email)
+                .nickname(nickname)
+                .status(status)
+                .build();
+    }
+
+    public static UserEntityDto create(UUID id, String email, String status) {
+        return UserEntityDto.builder()
+                .id(id)
+                .email(email)
+                .status(status)
+                .build();
+    }
+
+    public User toDomain() {
+        return UserFactory.create(id, email, nickname, status);
+    }
+}

--- a/src/main/java/com/knu/storyboard/user/business/port/UserRepository.java
+++ b/src/main/java/com/knu/storyboard/user/business/port/UserRepository.java
@@ -1,0 +1,20 @@
+package com.knu.storyboard.user.business.port;
+
+import com.knu.storyboard.user.business.dto.UserEntityDto;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository {
+    UserEntityDto save(String email, String nickName, String status);
+
+    void update(UserEntityDto userEntityDto);
+
+    void delete(UUID userId);
+
+    UserEntityDto getByEmail(String email);
+
+    Optional<UserEntityDto> findOptionalByEmail(String email);
+
+    UserEntityDto getById(UUID userId);
+}

--- a/src/main/java/com/knu/storyboard/user/business/service/UserFactory.java
+++ b/src/main/java/com/knu/storyboard/user/business/service/UserFactory.java
@@ -1,0 +1,25 @@
+package com.knu.storyboard.user.business.service;
+
+import com.knu.storyboard.user.domain.User;
+import com.knu.storyboard.user.domain.UserDomain;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserFactory {
+
+    public static User create(UUID id, String email, String nickname, String status) {
+        return UserDomain.create(id, email, nickname, status);
+    }
+
+    public static String generateNicknameFromEmail(String email) {
+        if (email == null || !email.contains("@")) {
+            throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다.");
+        }
+        return email.substring(0, email.indexOf("@"));
+    }
+}

--- a/src/main/java/com/knu/storyboard/user/business/service/UserService.java
+++ b/src/main/java/com/knu/storyboard/user/business/service/UserService.java
@@ -9,10 +9,11 @@ import com.knu.storyboard.user.business.dto.UserEntityDto;
 import com.knu.storyboard.user.business.port.UserRepository;
 import com.knu.storyboard.user.domain.User;
 import com.knu.storyboard.user.domain.UserStatus;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @Transactional
@@ -40,7 +41,7 @@ public class UserService {
 
     public void deleteUser(UUID userId) {
         oAuthRepository.deleteByUserId(userId);
-        
+
         userRepository.delete(userId);
     }
 }

--- a/src/main/java/com/knu/storyboard/user/business/service/UserService.java
+++ b/src/main/java/com/knu/storyboard/user/business/service/UserService.java
@@ -1,0 +1,46 @@
+package com.knu.storyboard.user.business.service;
+
+import com.knu.storyboard.auth.business.dto.JwtResponse;
+import com.knu.storyboard.auth.business.port.OAuthRepository;
+import com.knu.storyboard.auth.business.service.OAuthLoginService;
+import com.knu.storyboard.auth.domain.DeviceType;
+import com.knu.storyboard.user.business.dto.DummyRequest;
+import com.knu.storyboard.user.business.dto.UserEntityDto;
+import com.knu.storyboard.user.business.port.UserRepository;
+import com.knu.storyboard.user.domain.User;
+import com.knu.storyboard.user.domain.UserStatus;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final OAuthLoginService oAuthLoginService;
+    private final OAuthRepository oAuthRepository;
+
+    @Transactional
+    public JwtResponse dummyLogin(DummyRequest dummyRequest) {
+        String nickname = UserFactory.generateNicknameFromEmail(dummyRequest.email());
+        UserEntityDto userEntityDto = userRepository.findOptionalByEmail(dummyRequest.email())
+                .map(user -> userRepository.getByEmail(dummyRequest.email()))
+                .orElseGet(() -> userRepository.save(
+                        dummyRequest.email(),
+                        nickname,
+                        UserStatus.ACTIVE.name()
+                ));
+        User user = userEntityDto.toDomain();
+
+        return oAuthLoginService.generateTokensForUser(user.getId(), DeviceType.COMPUTER);
+    }
+
+    public void deleteUser(UUID userId) {
+        oAuthRepository.deleteByUserId(userId);
+        
+        userRepository.delete(userId);
+    }
+}

--- a/src/main/java/com/knu/storyboard/user/domain/User.java
+++ b/src/main/java/com/knu/storyboard/user/domain/User.java
@@ -1,0 +1,19 @@
+package com.knu.storyboard.user.domain;
+
+import com.knu.storyboard.user.business.dto.UserEntityDto;
+
+import java.util.UUID;
+
+public interface User {
+    UserEntityDto toEntityDto();
+
+    UUID getId();
+
+    String getEmail();
+
+    String getNickname();
+
+    boolean isWithdrawn();
+
+    boolean isInactive();
+}

--- a/src/main/java/com/knu/storyboard/user/domain/UserDomain.java
+++ b/src/main/java/com/knu/storyboard/user/domain/UserDomain.java
@@ -1,0 +1,40 @@
+package com.knu.storyboard.user.domain;
+
+import com.knu.storyboard.user.business.dto.UserEntityDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+import static com.knu.storyboard.user.domain.UserStatus.INACTIVE;
+import static com.knu.storyboard.user.domain.UserStatus.WITHDRAWN;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserDomain implements User {
+
+    private final UUID id;
+    private final String email;
+    private final String nickname;
+    private final String status;
+
+    public static UserDomain create(UUID id, String email, String nickname, String status) {
+        return new UserDomain(id, email, nickname, status);
+    }
+
+    @Override
+    public UserEntityDto toEntityDto() {
+        return UserEntityDto.create(id, email, nickname, status);
+    }
+
+    @Override
+    public boolean isWithdrawn() {
+        return this.status.equals(WITHDRAWN.name());
+    }
+
+    @Override
+    public boolean isInactive() {
+        return this.status.equals(INACTIVE.name());
+    }
+}

--- a/src/main/java/com/knu/storyboard/user/domain/UserStatus.java
+++ b/src/main/java/com/knu/storyboard/user/domain/UserStatus.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.user.domain;
+
+public enum UserStatus {
+    ACTIVE,
+    INACTIVE,
+    WITHDRAWN;
+}

--- a/src/main/java/com/knu/storyboard/user/exception/UserEmailDuplicateException.java
+++ b/src/main/java/com/knu/storyboard/user/exception/UserEmailDuplicateException.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.user.exception;
+
+public class UserEmailDuplicateException extends RuntimeException {
+    public UserEmailDuplicateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/knu/storyboard/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/knu/storyboard/user/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.user.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/knu/storyboard/user/infrastructure/entity/UserEntity.java
+++ b/src/main/java/com/knu/storyboard/user/infrastructure/entity/UserEntity.java
@@ -1,0 +1,59 @@
+package com.knu.storyboard.user.infrastructure.entity;
+
+import com.knu.storyboard.user.business.dto.UserEntityDto;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.UuidGenerator;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "USERS")
+public class UserEntity {
+    @Id
+    @UuidGenerator
+    @Column(columnDefinition = "char(36)", updatable = false, nullable = false)
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private UUID id;
+
+    @Column(unique = true)
+    private String email;
+
+    private String nickName;
+
+    @Enumerated(EnumType.STRING)
+    private UserEntityStatus status;
+
+    public static UserEntity create(String email, String nickName, String status) {
+        return UserEntity.builder()
+                .email(email)
+                .nickName(nickName)
+                .status(UserEntityStatus.valueOf(status))
+                .build();
+    }
+
+    public static UserEntity create(UUID id, String email, String nickName, String status) {
+        return UserEntity.builder()
+                .id(id)
+                .email(email)
+                .nickName(nickName)
+                .status(UserEntityStatus.valueOf(status))
+                .build();
+    }
+
+    public void update(UserEntityDto userEntityDto) {
+        this.email = userEntityDto.getEmail();
+        this.nickName = userEntityDto.getNickname();
+        this.status = UserEntityStatus.valueOf(userEntityDto.getStatus());
+    }
+
+    public UserEntityDto toEntityDto() {
+        return UserEntityDto.create(id, email, nickName, status.name());
+    }
+}

--- a/src/main/java/com/knu/storyboard/user/infrastructure/entity/UserEntityStatus.java
+++ b/src/main/java/com/knu/storyboard/user/infrastructure/entity/UserEntityStatus.java
@@ -1,0 +1,7 @@
+package com.knu.storyboard.user.infrastructure.entity;
+
+public enum UserEntityStatus {
+    ACTIVE,
+    INACTIVE,
+    WITHDRAWN;
+}

--- a/src/main/java/com/knu/storyboard/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/knu/storyboard/user/infrastructure/persistence/UserJpaRepository.java
@@ -1,0 +1,13 @@
+package com.knu.storyboard.user.infrastructure.persistence;
+
+import com.knu.storyboard.user.infrastructure.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserJpaRepository extends JpaRepository<UserEntity, UUID> {
+    Optional<UserEntity> findByEmail(String email);
+}

--- a/src/main/java/com/knu/storyboard/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/knu/storyboard/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.knu.storyboard.user.infrastructure.persistence;
+
+import com.knu.storyboard.user.business.dto.UserEntityDto;
+import com.knu.storyboard.user.business.port.UserRepository;
+import com.knu.storyboard.user.exception.UserNotFoundException;
+import com.knu.storyboard.user.infrastructure.entity.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public UserEntityDto save(String email, String nickName, String status) {
+        UserEntity user = UserEntity.create(email, nickName, status);
+        UserEntity savedUser = userJpaRepository.save(user);
+        return savedUser.toEntityDto();
+    }
+
+    @Override
+    public void update(UserEntityDto userEntityDto) {
+        UserEntity user = userJpaRepository.findById(userEntityDto.getId())
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        user.update(userEntityDto);
+    }
+
+    @Override
+    public void delete(UUID userId) {
+        UserEntity user = userJpaRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        userJpaRepository.delete(user);
+    }
+
+    public UserEntityDto getByEmail(String email) {
+        UserEntity user = userJpaRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        return user.toEntityDto();
+    }
+
+    @Override
+    public Optional<UserEntityDto> findOptionalByEmail(String email) {
+        return userJpaRepository.findByEmail(email)
+                .map(UserEntity::toEntityDto);
+    }
+
+    @Override
+    public UserEntityDto getById(UUID userId) {
+        UserEntity user = userJpaRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        return user.toEntityDto();
+    }
+}

--- a/src/main/java/com/knu/storyboard/user/presentation/api/UserApi.java
+++ b/src/main/java/com/knu/storyboard/user/presentation/api/UserApi.java
@@ -1,0 +1,38 @@
+package com.knu.storyboard.user.presentation.api;
+
+import com.knu.storyboard.auth.business.dto.JwtRefreshRequest;
+import com.knu.storyboard.auth.business.dto.JwtResponse;
+import com.knu.storyboard.auth.domain.AuthUser;
+import com.knu.storyboard.auth.presentation.annotation.Login;
+import com.knu.storyboard.user.business.dto.DummyRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Tag(name = "유저", description = "유저 관련 API")
+@RequestMapping("/api/user")
+public interface UserApi {
+
+    @PostMapping("/dummy")
+    @Operation(summary = "[테스트용] 임시 로그인용 JWT 생성", description = "테스트를 위해 OAuth를 거치지 않고도 서버에서 사용 가능한 인증용 JWT를 생성한다.")
+    ResponseEntity<JwtResponse> dummyLogin(
+            @RequestBody DummyRequest dummyRequest);
+
+    @PostMapping("/refresh")
+    @Operation(summary = "JWT 토큰 리프레쉬", description = "Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.")
+    ResponseEntity<JwtResponse> refreshToken(@RequestBody JwtRefreshRequest request);
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "로그아웃하여 저장된 토큰을 무효화합니다.")
+    ResponseEntity<Void> logout(
+            @RequestParam String deviceType,
+            @RequestParam UUID userId);
+
+    @DeleteMapping("/withdraw")
+    @Operation(summary = "회원 탈퇴", description = "회원 정보를 완전히 삭제합니다.")
+    ResponseEntity<Void> deleteAccount(@Parameter(hidden = true) @Login AuthUser authUser);
+}

--- a/src/main/java/com/knu/storyboard/user/presentation/controller/UserController.java
+++ b/src/main/java/com/knu/storyboard/user/presentation/controller/UserController.java
@@ -46,9 +46,9 @@ public class UserController implements UserApi {
     public ResponseEntity<Void> deleteAccount(@Parameter(hidden = true) @Login AuthUser authUser) {
         jwtService.logout(authUser.getId(), "COMPUTER");
         jwtService.logout(authUser.getId(), "PHONE");
-        
+
         userService.deleteUser(authUser.getId());
-        
+
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/knu/storyboard/user/presentation/controller/UserController.java
+++ b/src/main/java/com/knu/storyboard/user/presentation/controller/UserController.java
@@ -1,0 +1,54 @@
+package com.knu.storyboard.user.presentation.controller;
+
+import com.knu.storyboard.auth.business.dto.JwtRefreshRequest;
+import com.knu.storyboard.auth.business.dto.JwtResponse;
+import com.knu.storyboard.auth.business.service.JwtService;
+import com.knu.storyboard.auth.domain.AuthUser;
+import com.knu.storyboard.auth.presentation.annotation.Login;
+import com.knu.storyboard.auth.presentation.annotation.RequireAuth;
+import com.knu.storyboard.user.business.dto.DummyRequest;
+import com.knu.storyboard.user.business.service.UserService;
+import com.knu.storyboard.user.presentation.api.UserApi;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController implements UserApi {
+
+    private final UserService userService;
+    private final JwtService jwtService;
+
+    @Override
+    public ResponseEntity<JwtResponse> dummyLogin(DummyRequest dummyRequest) {
+        JwtResponse jwtResponse = userService.dummyLogin(dummyRequest);
+        return ResponseEntity.ok(jwtResponse);
+    }
+
+    @Override
+    public ResponseEntity<JwtResponse> refreshToken(JwtRefreshRequest request) {
+        JwtResponse jwtResponse = jwtService.refreshAccessToken(request);
+        return ResponseEntity.ok(jwtResponse);
+    }
+
+    @Override
+    public ResponseEntity<Void> logout(String deviceType, UUID userId) {
+        jwtService.logout(userId, deviceType);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    @RequireAuth
+    public ResponseEntity<Void> deleteAccount(@Parameter(hidden = true) @Login AuthUser authUser) {
+        jwtService.logout(authUser.getId(), "COMPUTER");
+        jwtService.logout(authUser.getId(), "PHONE");
+        
+        userService.deleteUser(authUser.getId());
+        
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,29 @@
 spring.application.name=storyboard
+spring.profiles.active=dev
+
+# MySQL
+spring.datasource.url=jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true
+spring.datasource.username=${MYSQL_USER}
+spring.datasource.password=${MYSQL_PASSWORD}
+
+# Redis
+spring.session.store-type=redis
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT}
+spring.data.redis.password=${REDIS_PASSWORD}
+
+# JPA
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=update
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.default_batch_fetch_size=1000
+
+# AWS S3
+cloud.aws.credentials.access-key=${AWS_ACCESS_KEY_ID}
+cloud.aws.credentials.secret-key=${AWS_SECRET_ACCESS_KEY}
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.s3.bucket=${S3_BUCKET_NAME}

--- a/src/test/java/com/knu/storyboard/DBTest/MySQLForTestConnectionTest.java
+++ b/src/test/java/com/knu/storyboard/DBTest/MySQLForTestConnectionTest.java
@@ -1,0 +1,38 @@
+package com.knu.storyboard.DBTest;
+
+import com.knu.storyboard.config.MySQLTestConfig;
+import com.knu.storyboard.config.MySQLTestContainerConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ExtendWith(MySQLTestContainerConfig.class)
+@Import(MySQLTestConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class MySQLForTestConnectionTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    public void testDatabaseConnection() throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            assertThat(connection).isNotNull();
+            assertThat(connection.isValid(1)).isTrue();
+
+            String url = connection.getMetaData().getURL();
+            System.out.println("Database URL: " + url);
+            assertThat(url).contains("jdbc:mysql://");
+        }
+    }
+}

--- a/src/test/java/com/knu/storyboard/DBTest/RedisForTestConnectionTest.java
+++ b/src/test/java/com/knu/storyboard/DBTest/RedisForTestConnectionTest.java
@@ -1,0 +1,71 @@
+package com.knu.storyboard.DBTest;
+
+import com.knu.storyboard.config.RedisTestConfig;
+import com.knu.storyboard.config.RedisTestContainerConfig;
+import com.knu.storyboard.config.TestEnvironmentConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataRedisTest
+@ExtendWith({RedisTestContainerConfig.class, TestEnvironmentConfig.class})
+@Import(RedisTestConfig.class)
+class RedisForTestConnectionTest {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Test
+    public void testRedisConnection() {
+        // Given
+        String testKey = "test:connection";
+        String testValue = "connection-successful";
+
+        // When
+        redisTemplate.opsForValue().set(testKey, testValue);
+        String retrievedValue = (String) redisTemplate.opsForValue().get(testKey);
+
+        // Then
+        assertThat(retrievedValue).isEqualTo(testValue);
+
+        // Cleanup
+        redisTemplate.delete(testKey);
+    }
+
+    @Test
+    public void testRedisConnectionInfo() {
+        // When
+        try (RedisConnection connection = redisTemplate.getConnectionFactory().getConnection()) {
+            // Then
+            assertThat(connection).isNotNull();
+            assertThat(connection.ping()).isNotNull();
+
+            System.out.println("Redis connection successful");
+            System.out.println("Redis ping response: " + connection.ping());
+        }
+    }
+
+    @Test
+    public void testRedisOperations() {
+        // Given
+        String hashKey = "test:hash";
+        String field = "field1";
+        String value = "value1";
+
+        // When
+        redisTemplate.opsForHash().put(hashKey, field, value);
+        String retrievedValue = (String) redisTemplate.opsForHash().get(hashKey, field);
+
+        // Then
+        assertThat(retrievedValue).isEqualTo(value);
+
+        // Cleanup
+        redisTemplate.delete(hashKey);
+    }
+}

--- a/src/test/java/com/knu/storyboard/StoryboardApplicationTests.java
+++ b/src/test/java/com/knu/storyboard/StoryboardApplicationTests.java
@@ -1,6 +1,10 @@
 package com.knu.storyboard;
 
+import com.knu.storyboard.config.MySQLTestContainerConfig;
+import com.knu.storyboard.config.RedisTestContainerConfig;
+import com.knu.storyboard.config.TestEnvironmentConfig;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest

--- a/src/test/java/com/knu/storyboard/StoryboardApplicationTests.java
+++ b/src/test/java/com/knu/storyboard/StoryboardApplicationTests.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@ExtendWith({RedisTestContainerConfig.class, MySQLTestContainerConfig.class, TestEnvironmentConfig.class})
 class StoryboardApplicationTests {
 
     @Test

--- a/src/test/java/com/knu/storyboard/StoryboardApplicationTests.java
+++ b/src/test/java/com/knu/storyboard/StoryboardApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class StoryboardApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/src/test/java/com/knu/storyboard/auth/business/service/JwtServiceTest.java
+++ b/src/test/java/com/knu/storyboard/auth/business/service/JwtServiceTest.java
@@ -1,0 +1,89 @@
+package com.knu.storyboard.auth.business.service;
+
+import com.knu.storyboard.auth.business.dto.JwtRefreshRequest;
+import com.knu.storyboard.auth.business.dto.JwtResponse;
+import com.knu.storyboard.auth.business.dto.TokenDTO;
+import com.knu.storyboard.auth.business.port.TokenRepository;
+import com.knu.storyboard.auth.business.service.validator.JwtValidator;
+import com.knu.storyboard.auth.domain.Token;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtServiceTest {
+
+    @Mock
+    private JwtFactory jwtFactory;
+
+    @Mock
+    private TokenRepository tokenRepository;
+
+    @Mock
+    private JwtValidator jwtValidator;
+
+    @Mock
+    private Token mockRefreshToken;
+
+    @Mock
+    private Token mockAccessToken;
+
+    @Mock
+    private Token mockNewRefreshToken;
+
+    @InjectMocks
+    private JwtService jwtService;
+
+    @Test
+    @DisplayName("유효한 Refresh Token으로 새로운 Access Token을 발급받는다")
+    void refreshAccessToken_ShouldReturnNewTokens() {
+        // Given
+        UUID userId = UUID.randomUUID();
+        String refreshTokenValue = "valid-refresh-token";
+        String deviceType = "COMPUTER";
+        JwtRefreshRequest request = new JwtRefreshRequest(refreshTokenValue, deviceType);
+
+        when(jwtFactory.parseToken(refreshTokenValue)).thenReturn(Optional.of(mockRefreshToken));
+        when(mockRefreshToken.getSubject()).thenReturn(userId.toString());
+        when(jwtFactory.createAccessToken(userId)).thenReturn(mockAccessToken);
+        when(jwtFactory.createRefreshToken(userId)).thenReturn(mockNewRefreshToken);
+        when(mockAccessToken.getValue()).thenReturn("new-access-token");
+        when(mockNewRefreshToken.getValue()).thenReturn("new-refresh-token");
+        when(mockNewRefreshToken.toTokenDTO()).thenReturn(mock(TokenDTO.class));
+
+        // When
+        JwtResponse result = jwtService.refreshAccessToken(request);
+
+        // Then
+        assertThat(result.accessToken()).isEqualTo("new-access-token");
+        assertThat(result.refreshToken()).isEqualTo("new-refresh-token");
+        verify(jwtValidator, times(1)).validateRefreshToken(mockRefreshToken, userId, deviceType);
+        verify(tokenRepository, times(1)).saveToken(eq(userId), eq(deviceType), any(TokenDTO.class));
+        verify(tokenRepository, times(1)).updateLastRefreshTime(userId, deviceType);
+    }
+
+    @Test
+    @DisplayName("로그아웃 시 토큰이 제거된다")
+    void logout_ShouldRemoveToken() {
+        // Given
+        UUID userId = UUID.randomUUID();
+        String deviceType = "COMPUTER";
+
+        // When
+        jwtService.logout(userId, deviceType);
+
+        // Then
+        verify(tokenRepository, times(1)).removeToken(userId, deviceType);
+    }
+}

--- a/src/test/java/com/knu/storyboard/auth/domain/AuthUserTest.java
+++ b/src/test/java/com/knu/storyboard/auth/domain/AuthUserTest.java
@@ -1,0 +1,48 @@
+package com.knu.storyboard.auth.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthUserTest {
+
+    @Mock
+    private Token mockToken;
+
+    @Test
+    @DisplayName("토큰으로부터 AuthUser를 생성할 수 있다")
+    void from_ShouldCreateAuthUserFromToken() {
+        // Given
+        UUID expectedUserId = UUID.randomUUID();
+        when(mockToken.getSubject()).thenReturn(expectedUserId.toString());
+
+        // When
+        AuthUser authUser = AuthUser.from(mockToken);
+
+        // Then
+        assertThat(authUser.getId()).isEqualTo(expectedUserId);
+    }
+
+    @Test
+    @DisplayName("Builder 패턴으로 AuthUser를 생성할 수 있다")
+    void builder_ShouldCreateAuthUser() {
+        // Given
+        UUID userId = UUID.randomUUID();
+
+        // When
+        AuthUser authUser = AuthUser.builder()
+                .id(userId)
+                .build();
+
+        // Then
+        assertThat(authUser.getId()).isEqualTo(userId);
+    }
+}

--- a/src/test/java/com/knu/storyboard/auth/domain/OAuthMappingTest.java
+++ b/src/test/java/com/knu/storyboard/auth/domain/OAuthMappingTest.java
@@ -1,0 +1,128 @@
+package com.knu.storyboard.auth.domain;
+
+import com.knu.storyboard.auth.business.dto.OAuthMappingEntityDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OAuthMappingTest {
+
+    @Test
+    @DisplayName("임시 OAuth 매핑을 생성할 수 있다")
+    void createTemporary_ShouldCreateTemporaryOAuthMapping() {
+        // Given
+        String providerId = "social123";
+        String providerEmail = "user@social.com";
+        String providerName = "Social User";
+        OAuthProvider provider = OAuthProvider.KAKAO;
+        OAuthToken oauthToken = OAuthToken.create(provider, "access-token", "refresh-token", 3600L);
+
+        // When
+        OAuthMapping mapping = OAuthMapping.createTemporary(providerId, providerEmail, providerName, provider, oauthToken);
+
+        // Then
+        assertThat(mapping.getSocialUserId()).isEqualTo(providerId);
+        assertThat(mapping.getSocialUserEmail()).isEqualTo(providerEmail);
+        assertThat(mapping.getSocialUserName()).isEqualTo(providerName);
+        assertThat(mapping.getProvider()).isEqualTo(provider);
+        assertThat(mapping.getOauthToken()).isEqualTo(oauthToken);
+        assertThat(mapping.isTemporary()).isTrue();
+        assertThat(mapping.getUserId()).isNull();
+    }
+
+    @Test
+    @DisplayName("사용자와 연결된 OAuth 매핑을 생성할 수 있다")
+    void createForUser_ShouldCreateOAuthMappingForUser() {
+        // Given
+        UUID userId = UUID.randomUUID();
+        String providerId = "social123";
+        String providerEmail = "user@social.com";
+        String providerName = "Social User";
+        OAuthProvider provider = OAuthProvider.KAKAO;
+        OAuthToken oauthToken = OAuthToken.create(provider, "access-token", "refresh-token", 3600L);
+
+        // When
+        OAuthMapping mapping = OAuthMapping.createForUser(userId, providerId, providerEmail, providerName, provider, oauthToken);
+
+        // Then
+        assertThat(mapping.getSocialUserId()).isEqualTo(providerId);
+        assertThat(mapping.getSocialUserEmail()).isEqualTo(providerEmail);
+        assertThat(mapping.getSocialUserName()).isEqualTo(providerName);
+        assertThat(mapping.getProvider()).isEqualTo(provider);
+        assertThat(mapping.getOauthToken()).isEqualTo(oauthToken);
+        assertThat(mapping.getUserId()).isEqualTo(userId);
+        assertThat(mapping.isTemporary()).isFalse();
+    }
+
+    @Test
+    @DisplayName("임시 매핑을 사용자와 연결할 수 있다")
+    void linkToUser_ShouldLinkTemporaryMappingToUser() {
+        // Given
+        UUID mappingId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        String providerId = "social123";
+        String providerEmail = "user@social.com";
+        String providerName = "Social User";
+        OAuthProvider provider = OAuthProvider.KAKAO;
+        OAuthToken oauthToken = OAuthToken.create(provider, "access-token", "refresh-token", 3600L);
+
+        OAuthMapping temporaryMapping = OAuthMapping.builder()
+                .id(mappingId)
+                .socialUserId(providerId)
+                .socialUserEmail(providerEmail)
+                .socialUserName(providerName)
+                .provider(provider)
+                .oauthToken(oauthToken)
+                .temporary(true)
+                .build();
+
+        // When
+        OAuthMapping linkedMapping = temporaryMapping.linkToUser(userId);
+
+        // Then
+        assertThat(linkedMapping.getId()).isEqualTo(mappingId);
+        assertThat(linkedMapping.getSocialUserId()).isEqualTo(providerId);
+        assertThat(linkedMapping.getUserId()).isEqualTo(userId);
+        assertThat(linkedMapping.isTemporary()).isFalse();
+    }
+
+    @Test
+    @DisplayName("OAuthMappingEntityDto로 변환할 수 있다")
+    void toDto_ShouldReturnCorrectDto() {
+        // Given
+        UUID mappingId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        String providerId = "social123";
+        String providerEmail = "user@social.com";
+        String providerName = "Social User";
+        OAuthProvider provider = OAuthProvider.KAKAO;
+        OAuthToken oauthToken = OAuthToken.create(provider, "access-token", "refresh-token", 3600L);
+
+        OAuthMapping mapping = OAuthMapping.builder()
+                .id(mappingId)
+                .socialUserId(providerId)
+                .socialUserEmail(providerEmail)
+                .socialUserName(providerName)
+                .provider(provider)
+                .userId(userId)
+                .oauthToken(oauthToken)
+                .temporary(false)
+                .build();
+
+        // When
+        OAuthMappingEntityDto dto = mapping.toDto();
+
+        // Then
+        assertThat(dto.getId()).isEqualTo(mappingId);
+        assertThat(dto.getSocialUserId()).isEqualTo(providerId);
+        assertThat(dto.getSocialUserEmail()).isEqualTo(providerEmail);
+        assertThat(dto.getSocialUserName()).isEqualTo(providerName);
+        assertThat(dto.getProvider()).isEqualTo(provider);
+        assertThat(dto.getUserId()).isEqualTo(userId);
+        assertThat(dto.getOauthToken()).isEqualTo(oauthToken);
+        assertThat(dto.isTemporary()).isFalse();
+    }
+}

--- a/src/test/java/com/knu/storyboard/auth/domain/OAuthTokenTest.java
+++ b/src/test/java/com/knu/storyboard/auth/domain/OAuthTokenTest.java
@@ -1,0 +1,102 @@
+package com.knu.storyboard.auth.domain;
+
+import com.knu.storyboard.auth.exception.OAuthErrorException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OAuthTokenTest {
+
+    @Test
+    @DisplayName("카카오 OAuth 토큰을 생성할 수 있다")
+    void ofKakao_ShouldCreateKakaoOAuthToken() {
+        // Given
+        String accessToken = "kakao-access-token";
+        String refreshToken = "kakao-refresh-token";
+        Long expiresIn = 3600L;
+
+        // When
+        OAuthToken token = OAuthToken.ofKakao(accessToken, refreshToken, expiresIn);
+
+        // Then
+        assertThat(token.getProvider()).isEqualTo(OAuthProvider.KAKAO);
+        assertThat(token.getAccessToken()).isEqualTo(accessToken);
+        assertThat(token.getRefreshToken()).isEqualTo(refreshToken);
+        assertThat(token.getExpiresIn()).isEqualTo(expiresIn);
+        assertThat(token.getIssuedAt()).isBefore(LocalDateTime.now().plusSeconds(1));
+        assertThat(token.getIssuedAt()).isAfter(LocalDateTime.now().minusSeconds(1));
+    }
+
+    @Test
+    @DisplayName("카카오 OAuth 토큰 생성 시 accessToken이 null이면 예외가 발생한다")
+    void ofKakao_ShouldThrowException_WhenAccessTokenIsNull() {
+        // Given
+        String accessToken = null;
+        String refreshToken = "refresh-token";
+        Long expiresIn = 3600L;
+
+        // When & Then
+        assertThatThrownBy(() -> OAuthToken.ofKakao(accessToken, refreshToken, expiresIn))
+                .isInstanceOf(OAuthErrorException.class)
+                .hasMessage("응답이 올바르지 않아 accessToken이 전달되지 않았습니다.");
+    }
+
+    @Test
+    @DisplayName("일반 OAuth 토큰을 생성할 수 있다")
+    void create_ShouldCreateOAuthToken() {
+        // Given
+        OAuthProvider provider = OAuthProvider.KAKAO;
+        String accessToken = "access-token";
+        String refreshToken = "refresh-token";
+        Long expiresIn = 7200L;
+
+        // When
+        OAuthToken token = OAuthToken.create(provider, accessToken, refreshToken, expiresIn);
+
+        // Then
+        assertThat(token.getProvider()).isEqualTo(provider);
+        assertThat(token.getAccessToken()).isEqualTo(accessToken);
+        assertThat(token.getRefreshToken()).isEqualTo(refreshToken);
+        assertThat(token.getExpiresIn()).isEqualTo(expiresIn);
+        assertThat(token.getIssuedAt()).isBefore(LocalDateTime.now().plusSeconds(1));
+        assertThat(token.getIssuedAt()).isAfter(LocalDateTime.now().minusSeconds(1));
+    }
+
+    @Test
+    @DisplayName("accessToken이 null이면 null을 반환한다")
+    void create_ShouldReturnNull_WhenAccessTokenIsNull() {
+        // Given
+        OAuthProvider provider = OAuthProvider.KAKAO;
+        String accessToken = null;
+        String refreshToken = "refresh-token";
+        Long expiresIn = 3600L;
+
+        // When
+        OAuthToken token = OAuthToken.create(provider, accessToken, refreshToken, expiresIn);
+
+        // Then
+        assertThat(token).isNull();
+    }
+
+    @Test
+    @DisplayName("refreshToken이 null이어도 토큰을 생성할 수 있다")
+    void create_ShouldCreateToken_WhenRefreshTokenIsNull() {
+        // Given
+        OAuthProvider provider = OAuthProvider.KAKAO;
+        String accessToken = "access-token";
+        String refreshToken = null;
+        Long expiresIn = 3600L;
+
+        // When
+        OAuthToken token = OAuthToken.create(provider, accessToken, refreshToken, expiresIn);
+
+        // Then
+        assertThat(token.getAccessToken()).isEqualTo(accessToken);
+        assertThat(token.getRefreshToken()).isNull();
+        assertThat(token.getProvider()).isEqualTo(provider);
+    }
+}

--- a/src/test/java/com/knu/storyboard/auth/domain/TokenTest.java
+++ b/src/test/java/com/knu/storyboard/auth/domain/TokenTest.java
@@ -1,0 +1,171 @@
+package com.knu.storyboard.auth.domain;
+
+import com.knu.storyboard.auth.business.dto.TokenDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenTest {
+
+    @Test
+    @DisplayName("토큰을 생성할 수 있다")
+    void of_ShouldCreateToken() {
+        // Given
+        TokenType type = TokenType.ACCESS;
+        String value = "test-token";
+        String subject = UUID.randomUUID().toString();
+        Date issueAt = new Date();
+        Date expiration = new Date(System.currentTimeMillis() + 3600000); // 1시간 후
+
+        // When
+        Token token = Token.of(type, value, subject, issueAt, expiration);
+
+        // Then
+        assertThat(token.getType()).isEqualTo(type);
+        assertThat(token.getValue()).isEqualTo(value);
+        assertThat(token.getSubject()).isEqualTo(subject);
+        assertThat(token.getIssueAt()).isEqualTo(issueAt);
+        assertThat(token.getExpiration()).isEqualTo(expiration);
+    }
+
+    @Test
+    @DisplayName("만료되지 않은 토큰은 유효하다")
+    void isExpired_ShouldReturnFalse_WhenTokenIsNotExpired() {
+        // Given
+        Date futureExpiration = new Date(System.currentTimeMillis() + 3600000); // 1시간 후
+        Token token = Token.of(
+                TokenType.ACCESS,
+                "test-token",
+                UUID.randomUUID().toString(),
+                new Date(),
+                futureExpiration
+        );
+
+        // When
+        boolean isExpired = token.isExpired();
+
+        // Then
+        assertThat(isExpired).isFalse();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰은 유효하지 않다")
+    void isExpired_ShouldReturnTrue_WhenTokenIsExpired() {
+        // Given
+        Date pastExpiration = new Date(System.currentTimeMillis() - 3600000); // 1시간 전
+        Token token = Token.of(
+                TokenType.ACCESS,
+                "test-token",
+                UUID.randomUUID().toString(),
+                new Date(),
+                pastExpiration
+        );
+
+        // When
+        boolean isExpired = token.isExpired();
+
+        // Then
+        assertThat(isExpired).isTrue();
+    }
+
+    @Test
+    @DisplayName("Access Token 타입을 올바르게 판별한다")
+    void isAccessToken_ShouldReturnTrue_WhenTokenIsAccessType() {
+        // Given
+        Token accessToken = Token.of(
+                TokenType.ACCESS,
+                "access-token",
+                UUID.randomUUID().toString(),
+                new Date(),
+                new Date(System.currentTimeMillis() + 3600000)
+        );
+
+        // When
+        boolean isAccessToken = accessToken.isAccessToken();
+
+        // Then
+        assertThat(isAccessToken).isTrue();
+    }
+
+    @Test
+    @DisplayName("Refresh Token 타입을 올바르게 판별한다")
+    void isRefreshToken_ShouldReturnTrue_WhenTokenIsRefreshType() {
+        // Given
+        Token refreshToken = Token.of(
+                TokenType.REFRESH,
+                "refresh-token",
+                UUID.randomUUID().toString(),
+                new Date(),
+                new Date(System.currentTimeMillis() + 7200000)
+        );
+
+        // When
+        boolean isRefreshToken = refreshToken.isRefreshToken();
+
+        // Then
+        assertThat(isRefreshToken).isTrue();
+    }
+
+    @Test
+    @DisplayName("같은 값의 토큰인지 확인할 수 있다")
+    void isSameValue_ShouldReturnTrue_WhenValuesAreEqual() {
+        // Given
+        String tokenValue = "test-token-value";
+        Token token = Token.of(
+                TokenType.ACCESS,
+                tokenValue,
+                UUID.randomUUID().toString(),
+                new Date(),
+                new Date(System.currentTimeMillis() + 3600000)
+        );
+
+        // When
+        boolean isSameValue = token.isSameValue(tokenValue);
+
+        // Then
+        assertThat(isSameValue).isTrue();
+    }
+
+    @Test
+    @DisplayName("다른 값의 토큰인지 확인할 수 있다")
+    void isSameValue_ShouldReturnFalse_WhenValuesAreDifferent() {
+        // Given
+        Token token = Token.of(
+                TokenType.ACCESS,
+                "original-token-value",
+                UUID.randomUUID().toString(),
+                new Date(),
+                new Date(System.currentTimeMillis() + 3600000)
+        );
+
+        // When
+        boolean isSameValue = token.isSameValue("different-token-value");
+
+        // Then
+        assertThat(isSameValue).isFalse();
+    }
+
+    @Test
+    @DisplayName("TokenDTO로 변환할 수 있다")
+    void toTokenDTO_ShouldReturnCorrectTokenDTO() {
+        // Given
+        String tokenValue = "test-token-value";
+        Token token = Token.of(
+                TokenType.ACCESS,
+                tokenValue,
+                UUID.randomUUID().toString(),
+                new Date(),
+                new Date(System.currentTimeMillis() + 3600000)
+        );
+
+        // When
+        TokenDTO tokenDTO = token.toTokenDTO();
+
+        // Then
+        assertThat(tokenDTO.value()).isEqualTo(tokenValue);
+    }
+}

--- a/src/test/java/com/knu/storyboard/auth/infrastructure/persistence/OAuthRepositoryImplTest.java
+++ b/src/test/java/com/knu/storyboard/auth/infrastructure/persistence/OAuthRepositoryImplTest.java
@@ -1,0 +1,149 @@
+package com.knu.storyboard.auth.infrastructure.persistence;
+
+import com.knu.storyboard.auth.business.dto.OAuthMappingEntityDto;
+import com.knu.storyboard.auth.business.dto.OAuthTokenDto;
+import com.knu.storyboard.auth.domain.OAuthProvider;
+import com.knu.storyboard.auth.exception.OAuthNotFoundException;
+import com.knu.storyboard.auth.infrastructure.entity.OAuthMappingEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OAuthRepositoryImplTest {
+
+    @Mock
+    private OAuthMappingJpaRepository oAuthMappingJpaRepository;
+
+    @Mock
+    private OAuthMappingEntity mockEntity;
+
+    @InjectMocks
+    private OAuthRepositoryImpl oAuthRepository;
+
+    @Test
+    @DisplayName("OAuth 매핑을 저장할 수 있다")
+    void save_ShouldSaveOAuthMapping() {
+        // Given
+        OAuthMappingEntityDto entityDto = createMockEntityDto();
+        when(oAuthMappingJpaRepository.save(any(OAuthMappingEntity.class))).thenReturn(mockEntity);
+        when(mockEntity.toEntityDto()).thenReturn(entityDto);
+
+        // When
+        OAuthMappingEntityDto result = oAuthRepository.save(entityDto);
+
+        // Then
+        assertThat(result).isEqualTo(entityDto);
+        verify(oAuthMappingJpaRepository, times(1)).save(any(OAuthMappingEntity.class));
+    }
+
+    @Test
+    @DisplayName("소셜 사용자 ID와 프로바이더로 OAuth 매핑을 찾을 수 있다")
+    void findBySocialUserIdAndProvider_ShouldReturnMapping_WhenExists() {
+        // Given
+        String socialUserId = "social123";
+        OAuthProvider provider = OAuthProvider.KAKAO;
+        OAuthMappingEntityDto expectedDto = createMockEntityDto();
+        
+        when(oAuthMappingJpaRepository.findBySocialUserIdAndProvider(socialUserId, provider))
+                .thenReturn(Optional.of(mockEntity));
+        when(mockEntity.toEntityDto()).thenReturn(expectedDto);
+
+        // When
+        Optional<OAuthMappingEntityDto> result = oAuthRepository.findBySocialUserIdAndProvider(socialUserId, provider);
+
+        // Then
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(expectedDto);
+        verify(oAuthMappingJpaRepository, times(1)).findBySocialUserIdAndProvider(socialUserId, provider);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 소셜 사용자 ID로 조회 시 빈 Optional을 반환한다")
+    void findBySocialUserIdAndProvider_ShouldReturnEmpty_WhenNotExists() {
+        // Given
+        String socialUserId = "nonexistent";
+        OAuthProvider provider = OAuthProvider.KAKAO;
+        
+        when(oAuthMappingJpaRepository.findBySocialUserIdAndProvider(socialUserId, provider))
+                .thenReturn(Optional.empty());
+
+        // When
+        Optional<OAuthMappingEntityDto> result = oAuthRepository.findBySocialUserIdAndProvider(socialUserId, provider);
+
+        // Then
+        assertThat(result).isEmpty();
+        verify(oAuthMappingJpaRepository, times(1)).findBySocialUserIdAndProvider(socialUserId, provider);
+    }
+
+    @Test
+    @DisplayName("토큰을 업데이트할 수 있다")
+    void updateToken_ShouldUpdateToken_WhenMappingExists() {
+        // Given
+        UUID mappingId = UUID.randomUUID();
+        OAuthTokenDto tokenDto = mock(OAuthTokenDto.class);
+        
+        when(oAuthMappingJpaRepository.findById(mappingId)).thenReturn(Optional.of(mockEntity));
+
+        // When
+        oAuthRepository.updateToken(mappingId, tokenDto);
+
+        // Then
+        verify(oAuthMappingJpaRepository, times(1)).findById(mappingId);
+        verify(mockEntity, times(1)).updateFromTokenDto(tokenDto);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 매핑 ID로 토큰 업데이트 시 예외가 발생한다")
+    void updateToken_ShouldThrowException_WhenMappingNotExists() {
+        // Given
+        UUID mappingId = UUID.randomUUID();
+        OAuthTokenDto tokenDto = mock(OAuthTokenDto.class);
+        
+        when(oAuthMappingJpaRepository.findById(mappingId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> oAuthRepository.updateToken(mappingId, tokenDto))
+                .isInstanceOf(OAuthNotFoundException.class)
+                .hasMessage("업데이트할 OAuth 매핑을 찾을 수 없습니다: " + mappingId);
+        
+        verify(mockEntity, never()).updateFromTokenDto(any());
+    }
+
+    @Test
+    @DisplayName("사용자 ID로 OAuth 매핑을 삭제할 수 있다")
+    void deleteByUserId_ShouldDeleteMappings() {
+        // Given
+        UUID userId = UUID.randomUUID();
+
+        // When
+        oAuthRepository.deleteByUserId(userId);
+
+        // Then
+        verify(oAuthMappingJpaRepository, times(1)).deleteByUserId(userId);
+    }
+
+    private OAuthMappingEntityDto createMockEntityDto() {
+        return OAuthMappingEntityDto.create(
+                UUID.randomUUID(),
+                "social123",
+                "user@social.com",
+                "Social User",
+                OAuthProvider.KAKAO,
+                UUID.randomUUID(),
+                null,
+                false
+        );
+    }
+}

--- a/src/test/java/com/knu/storyboard/auth/infrastructure/persistence/OAuthRepositoryImplTest.java
+++ b/src/test/java/com/knu/storyboard/auth/infrastructure/persistence/OAuthRepositoryImplTest.java
@@ -55,7 +55,7 @@ class OAuthRepositoryImplTest {
         String socialUserId = "social123";
         OAuthProvider provider = OAuthProvider.KAKAO;
         OAuthMappingEntityDto expectedDto = createMockEntityDto();
-        
+
         when(oAuthMappingJpaRepository.findBySocialUserIdAndProvider(socialUserId, provider))
                 .thenReturn(Optional.of(mockEntity));
         when(mockEntity.toEntityDto()).thenReturn(expectedDto);
@@ -75,7 +75,7 @@ class OAuthRepositoryImplTest {
         // Given
         String socialUserId = "nonexistent";
         OAuthProvider provider = OAuthProvider.KAKAO;
-        
+
         when(oAuthMappingJpaRepository.findBySocialUserIdAndProvider(socialUserId, provider))
                 .thenReturn(Optional.empty());
 
@@ -93,7 +93,7 @@ class OAuthRepositoryImplTest {
         // Given
         UUID mappingId = UUID.randomUUID();
         OAuthTokenDto tokenDto = mock(OAuthTokenDto.class);
-        
+
         when(oAuthMappingJpaRepository.findById(mappingId)).thenReturn(Optional.of(mockEntity));
 
         // When
@@ -110,14 +110,14 @@ class OAuthRepositoryImplTest {
         // Given
         UUID mappingId = UUID.randomUUID();
         OAuthTokenDto tokenDto = mock(OAuthTokenDto.class);
-        
+
         when(oAuthMappingJpaRepository.findById(mappingId)).thenReturn(Optional.empty());
 
         // When & Then
         assertThatThrownBy(() -> oAuthRepository.updateToken(mappingId, tokenDto))
                 .isInstanceOf(OAuthNotFoundException.class)
                 .hasMessage("업데이트할 OAuth 매핑을 찾을 수 없습니다: " + mappingId);
-        
+
         verify(mockEntity, never()).updateFromTokenDto(any());
     }
 

--- a/src/test/java/com/knu/storyboard/config/IntegrationTestConfig.java
+++ b/src/test/java/com/knu/storyboard/config/IntegrationTestConfig.java
@@ -1,0 +1,13 @@
+package com.knu.storyboard.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+
+@TestConfiguration
+@Import({
+        RedisTestConfig.class,
+        MySQLTestConfig.class
+})
+public class IntegrationTestConfig {
+}

--- a/src/test/java/com/knu/storyboard/config/MySQLTestConfig.java
+++ b/src/test/java/com/knu/storyboard/config/MySQLTestConfig.java
@@ -1,0 +1,31 @@
+package com.knu.storyboard.config;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import javax.sql.DataSource;
+
+@TestConfiguration
+public class MySQLTestConfig {
+
+    @Bean
+    @Primary
+    public DataSource testDataSource() {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(System.getProperty("spring.datasource.url"));
+        config.setUsername(System.getProperty("spring.datasource.username"));
+        config.setPassword(System.getProperty("spring.datasource.password"));
+        config.setDriverClassName(System.getProperty("spring.datasource.driver-class-name"));
+
+        config.setMaximumPoolSize(5);
+        config.setMinimumIdle(1);
+        config.setConnectionTimeout(30000);
+        config.setIdleTimeout(600000);
+        config.setMaxLifetime(1800000);
+
+        return new HikariDataSource(config);
+    }
+}

--- a/src/test/java/com/knu/storyboard/config/MySQLTestContainerConfig.java
+++ b/src/test/java/com/knu/storyboard/config/MySQLTestContainerConfig.java
@@ -1,0 +1,43 @@
+package com.knu.storyboard.config;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class MySQLTestContainerConfig implements BeforeAllCallback {
+    private static final String MYSQL_IMAGE = "mysql:8.0.36";
+    private static final String MYSQL_DB = "test_db";
+    private static final String MYSQL_USER = "test_user";
+    private static final String MYSQL_PASSWORD = "test_password";
+
+    private static final int MYSQL_PORT = 3306;
+    private static GenericContainer<?> mysqlContainer;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        mysqlContainer = new GenericContainer<>(DockerImageName.parse(MYSQL_IMAGE))
+                .withExposedPorts(MYSQL_PORT)
+                .withEnv("MYSQL_DATABASE", MYSQL_DB)
+                .withEnv("MYSQL_USER", MYSQL_USER)
+                .withEnv("MYSQL_PASSWORD", MYSQL_PASSWORD)
+                .withEnv("MYSQL_ROOT_PASSWORD", "root");
+
+        mysqlContainer.start();
+
+        String jdbcUrl = String.format("jdbc:mysql://%s:%d/%s?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC",
+                mysqlContainer.getHost(),
+                mysqlContainer.getMappedPort(MYSQL_PORT),
+                MYSQL_DB
+        );
+
+        System.setProperty("spring.datasource.url", jdbcUrl);
+        System.setProperty("spring.datasource.username", MYSQL_USER);
+        System.setProperty("spring.datasource.password", MYSQL_PASSWORD);
+        System.setProperty("spring.datasource.driver-class-name", "com.mysql.cj.jdbc.Driver");
+
+        System.setProperty("spring.jpa.properties.hibernate.dialect", "org.hibernate.dialect.MySQL8Dialect");
+        System.setProperty("spring.jpa.hibernate.ddl-auto", "create-drop");
+        System.setProperty("SPRING_JPA_SHOW_SQL", "false");
+    }
+}

--- a/src/test/java/com/knu/storyboard/config/RedisTestConfig.java
+++ b/src/test/java/com/knu/storyboard/config/RedisTestConfig.java
@@ -1,0 +1,60 @@
+package com.knu.storyboard.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@TestConfiguration
+public class RedisTestConfig {
+
+    @Bean
+    @Primary
+    public LettuceConnectionFactory testRedisConnectionFactory() {
+        String host = System.getProperty("spring.data.redis.host", "localhost");
+        int port = Integer.parseInt(System.getProperty("spring.data.redis.port", "6379"));
+        String password = System.getProperty("spring.data.redis.password", "");
+
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        if (!password.isEmpty()) {
+            config.setPassword(password);
+        }
+
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, Object> testRedisTemplate(LettuceConnectionFactory testRedisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(testRedisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean
+    @Primary
+    public RedissonClient testRedissonClient() {
+        String host = System.getProperty("spring.data.redis.host", "localhost");
+        int port = Integer.parseInt(System.getProperty("spring.data.redis.port", "6379"));
+        String password = System.getProperty("spring.data.redis.password", "");
+
+        Config config = new Config();
+        String address = String.format("redis://%s:%d", host, port);
+        config.useSingleServer()
+                .setAddress(address)
+                .setPassword(password.isEmpty() ? null : password);
+        return Redisson.create(config);
+    }
+}

--- a/src/test/java/com/knu/storyboard/config/RedisTestContainerConfig.java
+++ b/src/test/java/com/knu/storyboard/config/RedisTestContainerConfig.java
@@ -1,0 +1,29 @@
+package com.knu.storyboard.config;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class RedisTestContainerConfig implements BeforeAllCallback {
+    private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
+    private static final int REDIS_PORT = 6379;
+    private static final String REDIS_PASSWORD = "testpassword";
+    private GenericContainer redisGenericContainer;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        redisGenericContainer =
+                new GenericContainer(DockerImageName.parse(REDIS_IMAGE))
+                        .withExposedPorts(REDIS_PORT)
+                        .withCommand("redis-server --requirepass " + REDIS_PASSWORD)
+        ;
+
+        redisGenericContainer.start();
+
+        System.setProperty("spring.data.redis.host", redisGenericContainer.getHost());
+        System.setProperty("spring.data.redis.port",
+                String.valueOf(redisGenericContainer.getMappedPort(REDIS_PORT)));
+        System.setProperty("spring.data.redis.password", REDIS_PASSWORD);
+    }
+}

--- a/src/test/java/com/knu/storyboard/config/TestEnvironmentConfig.java
+++ b/src/test/java/com/knu/storyboard/config/TestEnvironmentConfig.java
@@ -1,0 +1,64 @@
+package com.knu.storyboard.config;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class TestEnvironmentConfig implements BeforeAllCallback {
+
+    // JWT 테스트용 시크릿 키
+    private static final String TEST_JWT_SECRET = "testSecretKeyForJwtTestingPurposesOnlyDoNotUseInProduction123456";
+
+    // Redis 테스트용 설정값
+    private static final String TEST_REDIS_HOST = "localhost";
+    private static final String TEST_REDIS_PORT = "6379";
+    private static final String TEST_REDIS_PASSWORD = "testpassword";
+
+    // MySQL 테스트용 설정값
+    private static final String TEST_MYSQL_HOST = "localhost";
+    private static final String TEST_MYSQL_PORT = "3306";
+    private static final String TEST_MYSQL_USER = "testuser";
+    private static final String TEST_MYSQL_PASSWORD = "testpassword";
+    private static final String TEST_MYSQL_DATABASE = "testdb";
+
+    // OAuth 테스트용 설정값
+    private static final String TEST_OAUTH_APP_REDIRECT_URI = "http://localhost:3000/test";
+
+    // Kakao OAuth 테스트용 설정값
+    private static final String TEST_KAKAO_REST_API_KEY = "test_kakao_api_key_for_testing_only";
+    private static final String TEST_KAKAO_BACKEND_REDIRECT_URI = "http://localhost:8080/auth/oauth/kakao/callback/test";
+
+    // S3 테스트용 설정값
+    private static final String AWS_ACCESS_KEY_ID = "AKIA123456789TESTKEY";
+    private static final String AWS_SECRET_ACCESS_KEY = "abc123xyz456def789ghi000testKeySecretValue";
+    private static final String S3_BUCKET_NAME = "my-test-bucket";
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        // JWT 설정
+        System.setProperty("SECRET_KEY", TEST_JWT_SECRET);
+
+        // Redis 설정
+        System.setProperty("REDIS_HOST", TEST_REDIS_HOST);
+        System.setProperty("REDIS_PORT", TEST_REDIS_PORT);
+        System.setProperty("REDIS_PASSWORD", TEST_REDIS_PASSWORD);
+
+        // MySQL 설정
+        System.setProperty("MYSQL_HOST", TEST_MYSQL_HOST);
+        System.setProperty("MYSQL_PORT", TEST_MYSQL_PORT);
+        System.setProperty("MYSQL_USER", TEST_MYSQL_USER);
+        System.setProperty("MYSQL_PASSWORD", TEST_MYSQL_PASSWORD);
+        System.setProperty("MYSQL_DATABASE", TEST_MYSQL_DATABASE);
+
+        // OAuth 설정
+        System.setProperty("OAUTH_APP_REDIRECT_URI", TEST_OAUTH_APP_REDIRECT_URI);
+
+        // Kakao OAuth 설정
+        System.setProperty("KAKAO_REST_API_KEY", TEST_KAKAO_REST_API_KEY);
+        System.setProperty("KAKAO_BACKEND_REDIRECT_URI", TEST_KAKAO_BACKEND_REDIRECT_URI);
+
+        // S3 설정
+        System.setProperty("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID);
+        System.setProperty("AWS_SECRET_ACCESS_KEY", AWS_SECRET_ACCESS_KEY);
+        System.setProperty("S3_BUCKET_NAME", S3_BUCKET_NAME);
+    }
+}

--- a/src/test/java/com/knu/storyboard/user/business/service/UserFactoryTest.java
+++ b/src/test/java/com/knu/storyboard/user/business/service/UserFactoryTest.java
@@ -1,0 +1,82 @@
+package com.knu.storyboard.user.business.service;
+
+import com.knu.storyboard.user.domain.User;
+import com.knu.storyboard.user.domain.UserStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserFactoryTest {
+
+    @Test
+    @DisplayName("사용자를 생성할 수 있다")
+    void create_ShouldCreateUser() {
+        // Given
+        UUID id = UUID.randomUUID();
+        String email = "test@example.com";
+        String nickname = "테스트유저";
+        String status = UserStatus.ACTIVE.name();
+
+        // When
+        User user = UserFactory.create(id, email, nickname, status);
+
+        // Then
+        assertThat(user.getId()).isEqualTo(id);
+        assertThat(user.getEmail()).isEqualTo(email);
+        assertThat(user.getNickname()).isEqualTo(nickname);
+    }
+
+    @Test
+    @DisplayName("이메일로부터 닉네임을 생성할 수 있다")
+    void generateNicknameFromEmail_ShouldReturnNickname() {
+        // Given
+        String email = "testuser@example.com";
+
+        // When
+        String nickname = UserFactory.generateNicknameFromEmail(email);
+
+        // Then
+        assertThat(nickname).isEqualTo("testuser");
+    }
+
+    @Test
+    @DisplayName("특수문자가 포함된 이메일에서도 닉네임을 생성할 수 있다")
+    void generateNicknameFromEmail_ShouldHandleSpecialCharacters() {
+        // Given
+        String email = "test.user+123@example.com";
+
+        // When
+        String nickname = UserFactory.generateNicknameFromEmail(email);
+
+        // Then
+        assertThat(nickname).isEqualTo("test.user+123");
+    }
+
+    @Test
+    @DisplayName("null 이메일로 닉네임 생성 시 예외가 발생한다")
+    void generateNicknameFromEmail_ShouldThrowException_WhenEmailIsNull() {
+        // Given
+        String email = null;
+
+        // When & Then
+        assertThatThrownBy(() -> UserFactory.generateNicknameFromEmail(email))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("유효하지 않은 이메일 형식입니다.");
+    }
+
+    @Test
+    @DisplayName("@ 기호가 없는 이메일로 닉네임 생성 시 예외가 발생한다")
+    void generateNicknameFromEmail_ShouldThrowException_WhenEmailHasNoAtSign() {
+        // Given
+        String email = "invalidEmail";
+
+        // When & Then
+        assertThatThrownBy(() -> UserFactory.generateNicknameFromEmail(email))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("유효하지 않은 이메일 형식입니다.");
+    }
+}

--- a/src/test/java/com/knu/storyboard/user/business/service/UserServiceTest.java
+++ b/src/test/java/com/knu/storyboard/user/business/service/UserServiceTest.java
@@ -1,0 +1,101 @@
+package com.knu.storyboard.user.business.service;
+
+import com.knu.storyboard.auth.business.dto.JwtResponse;
+import com.knu.storyboard.auth.business.port.OAuthRepository;
+import com.knu.storyboard.auth.business.service.OAuthLoginService;
+import com.knu.storyboard.auth.domain.DeviceType;
+import com.knu.storyboard.user.business.dto.DummyRequest;
+import com.knu.storyboard.user.business.dto.UserEntityDto;
+import com.knu.storyboard.user.business.port.UserRepository;
+import com.knu.storyboard.user.domain.UserStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private OAuthRepository oAuthRepository;
+
+    @Mock
+    private OAuthLoginService oAuthLoginService;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("회원 탈퇴 시 OAuth 매핑과 사용자 정보가 모두 삭제된다")
+    void deleteUser_ShouldDeleteOAuthMappingAndUser() {
+        // Given
+        UUID userId = UUID.randomUUID();
+
+        // When
+        userService.deleteUser(userId);
+
+        // Then
+        verify(oAuthRepository, times(1)).deleteByUserId(userId);
+        verify(userRepository, times(1)).delete(userId);
+    }
+
+    @Test
+    @DisplayName("기존 사용자가 더미 로그인을 하면 JWT를 반환한다")
+    void dummyLogin_ShouldReturnJwt_WhenUserExists() {
+        // Given
+        String email = "test@example.com";
+        DummyRequest dummyRequest = new DummyRequest(email);
+        UUID userId = UUID.randomUUID();
+        UserEntityDto existingUser = UserEntityDto.create(userId, email, "test", UserStatus.ACTIVE.name());
+        JwtResponse expectedJwt = new JwtResponse("access-token", "refresh-token");
+
+        when(userRepository.findOptionalByEmail(email)).thenReturn(Optional.of(existingUser));
+        when(userRepository.getByEmail(email)).thenReturn(existingUser);
+        when(oAuthLoginService.generateTokensForUser(userId, DeviceType.COMPUTER)).thenReturn(expectedJwt);
+
+        // When
+        JwtResponse result = userService.dummyLogin(dummyRequest);
+
+        // Then
+        assertThat(result).isEqualTo(expectedJwt);
+        verify(userRepository, never()).save(any(), any(), any());
+        verify(oAuthLoginService, times(1)).generateTokensForUser(userId, DeviceType.COMPUTER);
+    }
+
+    @Test
+    @DisplayName("새로운 사용자가 더미 로그인을 하면 사용자를 생성하고 JWT를 반환한다")
+    void dummyLogin_ShouldCreateUserAndReturnJwt_WhenUserNotExists() {
+        // Given
+        String email = "newuser@example.com";
+        DummyRequest dummyRequest = new DummyRequest(email);
+        UUID userId = UUID.randomUUID();
+        String expectedNickname = "newuser";
+        UserEntityDto newUser = UserEntityDto.create(userId, email, expectedNickname, UserStatus.ACTIVE.name());
+        JwtResponse expectedJwt = new JwtResponse("access-token", "refresh-token");
+
+        when(userRepository.findOptionalByEmail(email)).thenReturn(Optional.empty());
+        when(userRepository.save(email, expectedNickname, UserStatus.ACTIVE.name())).thenReturn(newUser);
+        when(oAuthLoginService.generateTokensForUser(userId, DeviceType.COMPUTER)).thenReturn(expectedJwt);
+
+        // When
+        JwtResponse result = userService.dummyLogin(dummyRequest);
+
+        // Then
+        assertThat(result).isEqualTo(expectedJwt);
+        verify(userRepository, times(1)).save(email, expectedNickname, UserStatus.ACTIVE.name());
+        verify(oAuthLoginService, times(1)).generateTokensForUser(userId, DeviceType.COMPUTER);
+    }
+}

--- a/src/test/java/com/knu/storyboard/user/business/service/UserServiceTest.java
+++ b/src/test/java/com/knu/storyboard/user/business/service/UserServiceTest.java
@@ -20,7 +20,6 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/knu/storyboard/user/domain/UserDomainTest.java
+++ b/src/test/java/com/knu/storyboard/user/domain/UserDomainTest.java
@@ -1,0 +1,103 @@
+package com.knu.storyboard.user.domain;
+
+import com.knu.storyboard.user.business.dto.UserEntityDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserDomainTest {
+
+    @Test
+    @DisplayName("사용자 도메인을 생성할 수 있다")
+    void create_ShouldCreateUserDomain() {
+        // Given
+        UUID id = UUID.randomUUID();
+        String email = "test@example.com";
+        String nickname = "테스트유저";
+        String status = "ACTIVE";
+
+        // When
+        UserDomain userDomain = UserDomain.create(id, email, nickname, status);
+
+        // Then
+        assertThat(userDomain.getId()).isEqualTo(id);
+        assertThat(userDomain.getEmail()).isEqualTo(email);
+        assertThat(userDomain.getNickname()).isEqualTo(nickname);
+        assertThat(userDomain.getStatus()).isEqualTo(status);
+    }
+
+    @Test
+    @DisplayName("활성 상태 사용자는 탈퇴하지 않은 상태이다")
+    void isWithdrawn_ShouldReturnFalse_WhenUserIsActive() {
+        // Given
+        UserDomain activeUser = UserDomain.create(
+                UUID.randomUUID(),
+                "test@example.com",
+                "테스트유저",
+                UserStatus.ACTIVE.name()
+        );
+
+        // When
+        boolean isWithdrawn = activeUser.isWithdrawn();
+
+        // Then
+        assertThat(isWithdrawn).isFalse();
+    }
+
+    @Test
+    @DisplayName("탈퇴 상태 사용자는 탈퇴한 상태이다")
+    void isWithdrawn_ShouldReturnTrue_WhenUserIsWithdrawn() {
+        // Given
+        UserDomain withdrawnUser = UserDomain.create(
+                UUID.randomUUID(),
+                "test@example.com",
+                "테스트유저",
+                UserStatus.WITHDRAWN.name()
+        );
+
+        // When
+        boolean isWithdrawn = withdrawnUser.isWithdrawn();
+
+        // Then
+        assertThat(isWithdrawn).isTrue();
+    }
+
+    @Test
+    @DisplayName("비활성 상태 사용자는 비활성 상태이다")
+    void isInactive_ShouldReturnTrue_WhenUserIsInactive() {
+        // Given
+        UserDomain inactiveUser = UserDomain.create(
+                UUID.randomUUID(),
+                "test@example.com",
+                "테스트유저",
+                UserStatus.INACTIVE.name()
+        );
+
+        // When
+        boolean isInactive = inactiveUser.isInactive();
+
+        // Then
+        assertThat(isInactive).isTrue();
+    }
+
+    @Test
+    @DisplayName("활성 상태 사용자는 비활성 상태가 아니다")
+    void isInactive_ShouldReturnFalse_WhenUserIsActive() {
+        // Given
+        UserDomain activeUser = UserDomain.create(
+                UUID.randomUUID(),
+                "test@example.com",
+                "테스트유저",
+                UserStatus.ACTIVE.name()
+        );
+
+        // When
+        boolean isInactive = activeUser.isInactive();
+
+        // Then
+        assertThat(isInactive).isFalse();
+    }
+}

--- a/src/test/java/com/knu/storyboard/user/domain/UserDomainTest.java
+++ b/src/test/java/com/knu/storyboard/user/domain/UserDomainTest.java
@@ -1,6 +1,5 @@
 package com.knu.storyboard.user.domain;
 
-import com.knu.storyboard.user.business.dto.UserEntityDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/knu/storyboard/user/presentation/controller/UserControllerTest.java
+++ b/src/test/java/com/knu/storyboard/user/presentation/controller/UserControllerTest.java
@@ -1,0 +1,66 @@
+package com.knu.storyboard.user.presentation.controller;
+
+import com.knu.storyboard.auth.business.dto.JwtRefreshRequest;
+import com.knu.storyboard.auth.business.dto.JwtResponse;
+import com.knu.storyboard.auth.business.service.JwtService;
+import com.knu.storyboard.auth.domain.AuthUser;
+import com.knu.storyboard.user.business.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private JwtService jwtService;
+
+    @InjectMocks
+    private UserController userController;
+
+    @Test
+    @DisplayName("JWT 리프레쉬 요청 시 새로운 토큰을 반환한다")
+    void refreshToken_ShouldReturnNewTokens() {
+        // Given
+        JwtRefreshRequest request = new JwtRefreshRequest("refresh-token", "COMPUTER");
+        JwtResponse expectedResponse = new JwtResponse("new-access-token", "new-refresh-token");
+        
+        when(jwtService.refreshAccessToken(request)).thenReturn(expectedResponse);
+
+        // When
+        ResponseEntity<JwtResponse> response = userController.refreshToken(request);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(expectedResponse);
+        verify(jwtService, times(1)).refreshAccessToken(request);
+    }
+
+    @Test
+    @DisplayName("로그아웃 요청 시 토큰을 무효화한다")
+    void logout_ShouldInvalidateToken() {
+        // Given
+        UUID userId = UUID.randomUUID();
+        String deviceType = "COMPUTER";
+
+        // When
+        ResponseEntity<Void> response = userController.logout(deviceType, userId);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        verify(jwtService, times(1)).logout(userId, deviceType);
+    }
+}

--- a/src/test/java/com/knu/storyboard/user/presentation/controller/UserControllerTest.java
+++ b/src/test/java/com/knu/storyboard/user/presentation/controller/UserControllerTest.java
@@ -3,7 +3,6 @@ package com.knu.storyboard.user.presentation.controller;
 import com.knu.storyboard.auth.business.dto.JwtRefreshRequest;
 import com.knu.storyboard.auth.business.dto.JwtResponse;
 import com.knu.storyboard.auth.business.service.JwtService;
-import com.knu.storyboard.auth.domain.AuthUser;
 import com.knu.storyboard.user.business.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,7 +36,7 @@ class UserControllerTest {
         // Given
         JwtRefreshRequest request = new JwtRefreshRequest("refresh-token", "COMPUTER");
         JwtResponse expectedResponse = new JwtResponse("new-access-token", "new-refresh-token");
-        
+
         when(jwtService.refreshAccessToken(request)).thenReturn(expectedResponse);
 
         // When


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #5 

## 배경

기존의 계층형 아키텍처에서 발생하는 강한 결합도와 테스트의 어려움을 해결하고, 비즈니스 로직을 외부 의존성으로부터 격리하기 위해 헥사고날 아키텍처를 도입했다. 이를 통해 도메인 중심의 설계와 포트-어댑터 패턴을 적용하여 확장 가능하고 유지보수성이 높은 시스템을 구축했다.

## 작업 내용

### 헥사고날 아키텍처 구조 구현

**도메인 계층**
- User, UserDomain, Token, OAuthMapping, AuthUser 등 순수 비즈니스 로직 구현
- UserStatus, TokenType, OAuthProvider 등 도메인 개념을 값 객체로 표현
- 외부 의존성 없는 도메인 모델 설계

**포트 정의**
- 인바운드 포트: UserService, OAuthService로 유스케이스 정의
- 아웃바운드 포트: UserRepository, OAuthRepository, TokenRepository로 데이터 저장소 추상화

**어댑터 구현**
- Primary Adapters: UserController, OAuthController로 REST API 처리
- Secondary Adapters: UserRepositoryImpl, OAuthRepositoryImpl로 JPA 구현
- 외부 서비스 어댑터: KakaoOAuthService, S3FileStorageService

### 핵심 기능 구현

**인증 시스템**
- JWT 기반 토큰 생성, 검증, 리프레쉬 기능
- OAuth 소셜 로그인 처리 로직
- 인증 미들웨어를 통한 요청 처리

**사용자 관리**
- 사용자 생성, 조회, 삭제 기능
- OAuth 매핑을 통한 소셜 계정 연동
- 회원 탈퇴 시 관련 데이터 완전 삭제

**API 엔드포인트**
- JWT 리프레쉬, 로그아웃, 회원 탈퇴 API
- 개발환경을 위한 더미 로그인 기능

### 테스트 코드 작성

**도메인 테스트**
- UserDomainTest, TokenTest, OAuthMappingTest로 비즈니스 로직 검증
- 외부 의존성 없는 순수 도메인 테스트 구현

**서비스 테스트**
- UserServiceTest, JwtServiceTest로 유스케이스 검증
- Mock을 활용한 포트 기반 테스트

**어댑터 테스트**
- UserControllerTest, OAuthRepositoryImplTest로 어댑터 기능 검증
- Given-When-Then 패턴으로 테스트 가독성 향상

### 인프라 설정
- MySQL, Redis 연결 설정 및 테스트
- AWS S3 파일 스토리지 연동
- 통합 예외 처리 시스템 구축

### 📸 스크린샷
<img width="1310" height="704" alt="image" src="https://github.com/user-attachments/assets/d0490c35-7323-4344-9954-38ec115a6cf4" />

## ✏ Git Close
close #5 