### PR TITLE
Refactor#17 Oauth API 에 `redirectUrl` 쿼리 파라미터 추가

### DIFF
--- a/src/main/java/com/knu/storyboard/auth/business/dto/OAuthContext.java
+++ b/src/main/java/com/knu/storyboard/auth/business/dto/OAuthContext.java
@@ -2,15 +2,17 @@ package com.knu.storyboard.auth.business.dto;
 
 import com.knu.storyboard.auth.domain.DeviceType;
 import com.knu.storyboard.auth.domain.OAuthProvider;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 
 @Builder(access = AccessLevel.PROTECTED)
-public record OAuthContext(OAuthProvider oAuthProvider, DeviceType deviceType) {
-    public static OAuthContext of(OAuthProvider oAuthProvider, DeviceType deviceType) {
+public record OAuthContext(OAuthProvider oAuthProvider, DeviceType deviceType, String redirectUrl) {
+    public static OAuthContext of(OAuthProvider oAuthProvider, DeviceType deviceType, String redirectUrl) {
         return OAuthContext.builder()
                 .oAuthProvider(oAuthProvider)
                 .deviceType(deviceType)
+                .redirectUrl(redirectUrl)
                 .build();
     }
 }

--- a/src/main/java/com/knu/storyboard/auth/domain/OAuthState.java
+++ b/src/main/java/com/knu/storyboard/auth/domain/OAuthState.java
@@ -1,0 +1,47 @@
+package com.knu.storyboard.auth.domain;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import com.knu.storyboard.auth.exception.OAuthBadRequestException;
+
+public record OAuthState(DeviceType deviceType, String redirectUrl) {
+
+    private static final String DELIMITER = "|";
+
+    public static OAuthState of(DeviceType deviceType, String redirectUrl) {
+        if (deviceType == null) {
+            throw new OAuthBadRequestException("state값이 없습니다.");
+        }
+        return new OAuthState(deviceType, redirectUrl);
+    }
+
+    public static OAuthState fromStateParameter(String state) {
+        if (state == null || state.isEmpty()) {
+            throw new OAuthBadRequestException("state값이 없습니다.");
+        }
+
+        String[] parts = state.split("\\" + DELIMITER, 2);
+        DeviceType deviceType = DeviceType.fromString(parts[0]);
+
+        if (parts.length == 1) {
+            return new OAuthState(deviceType, null);
+        }
+
+        String encodedRedirectUrl = parts[1];
+        String decodedRedirectUrl = encodedRedirectUrl.isEmpty()
+                ? null
+                : URLDecoder.decode(encodedRedirectUrl, StandardCharsets.UTF_8);
+
+        return new OAuthState(deviceType, decodedRedirectUrl);
+    }
+
+    public String toStateParameter() {
+        String encodedRedirectUrl = redirectUrl == null || redirectUrl.isBlank()
+                ? ""
+                : URLEncoder.encode(redirectUrl, StandardCharsets.UTF_8);
+
+        return deviceType.name() + DELIMITER + encodedRedirectUrl;
+    }
+}

--- a/src/main/java/com/knu/storyboard/auth/presentation/api/OAuthApi.java
+++ b/src/main/java/com/knu/storyboard/auth/presentation/api/OAuthApi.java
@@ -1,8 +1,6 @@
 package com.knu.storyboard.auth.presentation.api;
 
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,16 +8,20 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.view.RedirectView;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 @RequestMapping("/api/auth/oauth")
 @Tag(name = "OAuth", description = "OAuth 관련 API")
 public interface OAuthApi {
 
     @GetMapping("/{provider}/login")
     @Operation(summary = "OAuth 로그인 페이지 이동",
-            description = "provider별 로그인 페이지로 이동한다. state는 deviceType(COMPUTER/PHONE)")
+               description = "provider별 로그인 페이지로 이동한다. deviceType(COMPUTER/PHONE)과 redirectUrl을 전달할 수 있다.")
     RedirectView redirectToOAuthLoginPage(
             @PathVariable("provider") String provider,
-            @RequestParam(value = "state", required = false) String state);
+            @RequestParam(value = "deviceType", required = false) String deviceType,
+            @RequestParam(value = "redirectUrl", required = false) String redirectUrl);
 
     @GetMapping("/{provider}/callback")
     @Operation(summary = "OAuth용 콜백 [직접 사용 금지]",

--- a/src/main/java/com/knu/storyboard/auth/presentation/controller/OAuthController.java
+++ b/src/main/java/com/knu/storyboard/auth/presentation/controller/OAuthController.java
@@ -1,8 +1,8 @@
 package com.knu.storyboard.auth.presentation.controller;
 
-import com.knu.storyboard.auth.business.service.OAuthLoginService;
-import com.knu.storyboard.auth.presentation.api.OAuthApi;
-import lombok.RequiredArgsConstructor;
+import java.net.URI;
+import java.util.Optional;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,7 +11,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.view.RedirectView;
 
-import java.net.URI;
+import com.knu.storyboard.auth.business.service.OAuthLoginService;
+import com.knu.storyboard.auth.domain.DeviceType;
+import com.knu.storyboard.auth.domain.OAuthState;
+import com.knu.storyboard.auth.presentation.api.OAuthApi;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,11 +27,14 @@ public class OAuthController implements OAuthApi {
     @Override
     public RedirectView redirectToOAuthLoginPage(
             @PathVariable("provider") String provider,
-            @RequestParam(value = "state", required = false) String state) {
+            @RequestParam(value = "deviceType", required = false) String deviceType,
+            @RequestParam(value = "redirectUrl", required = false) String redirectUrl) {
 
-        String redirectUrl = oAuthLoginService.getOAuthLoginUrl(provider, state);
+        String state = OAuthState.of(DeviceType.fromString(Optional.ofNullable(deviceType).orElse(DeviceType.COMPUTER.name())), redirectUrl)
+                .toStateParameter();
 
-        return new RedirectView(redirectUrl);
+        String redirectViewUrl = oAuthLoginService.getOAuthLoginUrl(provider, state);
+        return new RedirectView(redirectViewUrl);
     }
 
     @Override


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- resolve #17

## 📚 배경
기존 OAuth 로그인은 고정된 리다이렉트 URL(`OAUTH_APP_REDIRECT_URI`) 로만 토큰을 전달할 수 있어, 클라이언트 측에서 동적으로 리다이렉트 URL을 지정할 수 없었습니다.

## 📝 작업 내용

### OAuthState 도메인 객체 추가
- `deviceType`과 `redirectUrl`을 OAuth state 파라미터로 안전하게 인코딩/디코딩
- URL 인코딩을 통해 특수문자가 포함된 리다이렉트 URL도 안전하게 처리
- 구분자(`|`)를 사용하여 두 값을 결합

### OAuthContext에 redirectUrl 필드 추가
- 비즈니스 로직에서 리다이렉트 URL 정보를 전달할 수 있도록 컨텍스트 확장

### OAuth 로그인 서비스 로직 개선
- `parseOAuthContext()`: state 파라미터에서 `redirectUrl` 추출
- `handleOAuthCallback()`:`redirectUrl`이 있으면 사용, 없으면 기본값 사용

### OAuth API 파라미터 변경
- 기존: `state` 파라미터로 deviceType만 전달
- 변경: `deviceType`과 `redirectUrl`을 별도 쿼리 파라미터로 분리
- 스웨거ㅓ 문서 업데이트

### OAuthController 구현
- 두 개의 쿼리 파라미터를 받아 `OAuthState`로 변환
- `deviceType` 기본값: `COMPUTER`
- `redirectUrl`이 없으면 환경변수의 기본값 사용

## 🔍 사용 예시
```
GET /api/auth/oauth/kakao/login?deviceType=PHONE&redirectUrl=https://localhost:5173/auth/callback
```